### PR TITLE
CI: only run once (prevent duplicate runs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
-on:
-  push:
-  pull_request:
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   cachix:


### PR DESCRIPTION
The `[x, y]` syntax only runs one job at a time.