### PR TITLE
pass vkd3dArches to the wine derivations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642265851,
-        "narHash": "sha256-6J2paKHuQKhaBJNVf7k1NI9pqiMiAlkgt0x7obFtQ70=",
+        "lastModified": 1643119265,
+        "narHash": "sha256-mmDEctIkHSWcC/HRpeaw6QOe+DbNOSzc0wsXAHOZWwo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60dec7aa319dc620cd77ecae8ce48f5374450452",
+        "rev": "b05d2077ebe219f6a47825767f8bab5c6211d200",
         "type": "github"
       },
       "original": {

--- a/pkgs/wine/default.nix
+++ b/pkgs/wine/default.nix
@@ -41,9 +41,13 @@ let
     pkgArches = [ pkgs pkgsi686Linux ];
     platforms = [ "x86_64-linux" ];
     stdenv = stdenv_32bit;
+    vkd3dArches = lib.optionals supportFlags.vkd3dSupport [ vkd3d vkd3d_i686 ];
   };
 
   pnameGen = n: n + lib.optionalString (build == "full") "-full";
+
+  vkd3d = pkgs.callPackage "${inputs.nixpkgs}/pkgs/misc/emulators/wine/vkd3d.nix" { };
+  vkd3d_i686 = pkgsi686Linux.callPackage "${inputs.nixpkgs}/pkgs/misc/emulators/wine/vkd3d.nix" { };
 in
 {
   wine-tkg =

--- a/pkgs/wine/supportFlags.nix
+++ b/pkgs/wine/supportFlags.nix
@@ -37,6 +37,7 @@ rec {
     faudioSupport = false;
     vkd3dSupport = false;
     embedInstallers = false;
+    waylandSupport = false;
   };
 
   full = base // {


### PR DESCRIPTION
NixOS/nixpkgs#153932 added an additonal argument to the wine base
derivation, controlling which variants of vkd3d are included in the wine
distribution.

This needs to be manually added to 3rd party wine derivations, as there
is no fallback to the previous behaviour.