### PR TITLE
Fix wine derivations with the recent nixpkgs change

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643119265,
-        "narHash": "sha256-mmDEctIkHSWcC/HRpeaw6QOe+DbNOSzc0wsXAHOZWwo=",
+        "lastModified": 1645162597,
+        "narHash": "sha256-S4sRtJBqVlBg4H7EPAv0NFofGNCayHEMpLnUzGNCCKM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b05d2077ebe219f6a47825767f8bab5c6211d200",
+        "rev": "b715fcd9d9e26b99182d902c6b5694be0daae6d5",
         "type": "github"
       },
       "original": {

--- a/pkgs/wine/default.nix
+++ b/pkgs/wine/default.nix
@@ -35,7 +35,7 @@ let
   defaults = with pkgs; {
     inherit supportFlags;
     patches = [ ];
-    buildScript = "${inputs.nixpkgs}/pkgs/misc/emulators/wine/builder-wow.sh";
+    buildScript = "${inputs.nixpkgs}/pkgs/applications/emulators/wine/builder-wow.sh";
     configureFlags = [ "--disable-tests" ];
     geckos = [ gecko32 gecko64 ];
     mingwGccs = with pkgsCross; [ mingw32.buildPackages.gcc mingwW64.buildPackages.gcc ];
@@ -48,15 +48,15 @@ let
 
   pnameGen = n: n + lib.optionalString (build == "full") "-full";
 
-  vkd3d = pkgs.callPackage "${inputs.nixpkgs}/pkgs/misc/emulators/wine/vkd3d.nix" { };
-  vkd3d_i686 = pkgsi686Linux.callPackage "${inputs.nixpkgs}/pkgs/misc/emulators/wine/vkd3d.nix" { };
+  vkd3d = pkgs.callPackage "${inputs.nixpkgs}/pkgs/applications/emulators/wine/vkd3d.nix" { };
+  vkd3d_i686 = pkgsi686Linux.callPackage "${inputs.nixpkgs}/pkgs/applications/emulators/wine/vkd3d.nix" { };
 in
 {
   wine-tkg =
     let
       pname = pnameGen "wine-tkg";
     in
-    callPackage "${inputs.nixpkgs}/pkgs/misc/emulators/wine/base.nix" (defaults // rec {
+    callPackage "${inputs.nixpkgs}/pkgs/applications/emulators/wine/base.nix" (defaults // rec {
       name = "${pname}-${version}";
       version = "7.0";
       src = fetchFromGitHub {
@@ -78,7 +78,7 @@ in
         sha256 = "sha256-2gBfsutKG0ok2ISnnAUhJit7H2TLPDpuP5gvfMVE44o=";
       };
     in
-    (callPackage "${inputs.nixpkgs}/pkgs/misc/emulators/wine/base.nix" (defaults // rec {
+    (callPackage "${inputs.nixpkgs}/pkgs/applications/emulators/wine/base.nix" (defaults // rec {
       name = "${pname}-${version}";
       inherit version;
       src = fetchFromGitHub {
@@ -87,7 +87,7 @@ in
         rev = "wine-${version}";
         sha256 = "sha256-uDdjgibNGe8m1EEL7LGIkuFd1UUAFM21OgJpbfiVPJs=";
       };
-      patches = [ "${inputs.nixpkgs}/pkgs/misc/emulators/wine/cert-path.patch" ] ++ self.lib.mkPatches ./patches;
+      patches = [ "${inputs.nixpkgs}/pkgs/applications/emulators/wine/cert-path.patch" ] ++ self.lib.mkPatches ./patches;
     })).overrideDerivation (self: {
       prePatch = ''
         patchShebangs tools


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/8d65e832f0a18f60e2040940c80d96373ac8b88c has moved all emulators from pkgs/misc/emulators to pkgs/applications/emulators. 

This PR applies that change to nix-gaming.