### PR TITLE
Add legendaryBuilder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         command:
           - 'nix flake check'
-          - 'nix run nixpkgs#alejandra -- -c .'
+          - 'nix fmt'
     steps:
       - uses: actions/checkout@v3.0.2
       - uses: cachix/install-nix-action@v17

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Package                   | Description
 `wine-tkg`                | Wine optimized for games
 `winestreamproxy`         | Wine-Discord RPC (broken)
 
+* `legendaryBuilder` is a function that installs games with `legendary-gl`. You
+are expected to log in before using it, with `legendary auth`.
+The function takes an attrset containing at least the attrset `games` which
+includes the games you want installed. Optionally, you can set an `opts`
+attrset that will set the options you set inside for all games listed.
+
+You can find a usage example in [example.nix](./example.nix).
+
 * `osu-lazer-bin` is an osu!lazer build that is extracted from official binary
 AppImage releases in order to preserve multiplayer functions.
 
@@ -24,10 +32,6 @@ Installation will take a bit of time. It will download and install about 400MB
 of files. In any case, **do not stop the command!**
 If anything goes wrong and for some reason osu! won't start, delete the `~/.osu`
 directory and re-run `osu-stable`.
-
-* `rocket-league` relies on `legendary-gl`, which expects you to log in. It's
-best to do that before running RL, by adding `legendary-gl` in a nix shell and
-running `legendary auth`.
 
 * `technic-launcher` will guide you through the install process, just like it
 normally would. Some modpacks will complain about libraries, and that is

--- a/example.nix
+++ b/example.nix
@@ -1,22 +1,46 @@
-inputs: let
-  rocket-league = inputs.self.lib.legendaryBuilder {
-    games = {
-      rocket-league = {
-        desktopName = "Rocket League";
-        tricks = ["dxvk" "win10"];
-        icon = builtins.fetchurl {
-          url = "https://www.pngkey.com/png/full/16-160666_rocket-league-png.png";
-          name = "rocket-league.png";
-          sha256 = "09n90zvv8i8bk3b620b6qzhj37jsrhmxxf7wqlsgkifs4k2q8qpf";
-        };
-        discordIntegration = false;
-      };
-    };
+{
+  environment.systemPackages =
+    [
+      # or home.packages
+      # ...
+    ]
+    ++ builtins.attrValues # construct a list from the output attrset
 
-    opts = {
-      wine = packages.wine-tkg;
-      inherit (packages) wine-discord-ipc-bridge;
-    };
-  };
-in
-  rocket-league
+    (inputs.nix-gaming.packages.${pkgs.system}.legendaryBuilder {
+      games = {
+        rocket-league = {
+          # find names with `legendary list`
+          desktopName = "Rocket League";
+
+          # find out on lutris/winedb/protondb
+          tricks = ["dxvk" "win10"];
+
+          # google "<game name> logo"
+          icon = builtins.fetchurl {
+            url = "https://www.pngkey.com/png/full/16-160666_rocket-league-png.png";
+            name = "rocket-league.png";
+            sha256 = "09n90zvv8i8bk3b620b6qzhj37jsrhmxxf7wqlsgkifs4k2q8qpf";
+          };
+
+          # if you don't want winediscordipcbridge running for this game
+          discordIntegration = false;
+          # if you dont' want to launch the game using gamemode
+          gamemodeIntegration = false;
+
+          preCommands = ''
+            echo "the game will start!"
+          '';
+
+          postCommands = ''
+            the game has stopped!
+          '';
+        };
+      };
+
+      opts = {
+        # same options as above can be provided here, and will be applied to all games
+        # NOTE: game-specific options take precedence
+        wine = packages.wine-tkg;
+      };
+    });
+}

--- a/example.nix
+++ b/example.nix
@@ -1,0 +1,22 @@
+inputs: let
+  rocket-league = inputs.self.lib.legendaryBuilder {
+    games = {
+      rocket-league = {
+        desktopName = "Rocket League";
+        tricks = ["dxvk" "win10"];
+        icon = builtins.fetchurl {
+          url = "https://www.pngkey.com/png/full/16-160666_rocket-league-png.png";
+          name = "rocket-league.png";
+          sha256 = "09n90zvv8i8bk3b620b6qzhj37jsrhmxxf7wqlsgkifs4k2q8qpf";
+        };
+        discordIntegration = false;
+      };
+    };
+
+    opts = {
+      wine = packages.wine-tkg;
+      inherit (packages) wine-discord-ipc-bridge;
+    };
+  };
+in
+  rocket-league

--- a/example.nix
+++ b/example.nix
@@ -1,46 +1,48 @@
 {
   environment.systemPackages =
+    # or home.packages
     [
-      # or home.packages
       # ...
     ]
-    ++ builtins.attrValues # construct a list from the output attrset
+    # construct a list from the output attrset
+    ++ builtins.attrValues (inputs.nix-gaming.lib.legendaryBuilder
+      {
+        inherit (pkgs) system;
 
-    (inputs.nix-gaming.packages.${pkgs.system}.legendaryBuilder {
-      games = {
-        rocket-league = {
-          # find names with `legendary list`
-          desktopName = "Rocket League";
+        games = {
+          rocket-league = {
+            # find names with `legendary list`
+            desktopName = "Rocket League";
 
-          # find out on lutris/winedb/protondb
-          tricks = ["dxvk" "win10"];
+            # find out on lutris/winedb/protondb
+            tricks = ["dxvk" "win10"];
 
-          # google "<game name> logo"
-          icon = builtins.fetchurl {
-            url = "https://www.pngkey.com/png/full/16-160666_rocket-league-png.png";
-            name = "rocket-league.png";
-            sha256 = "09n90zvv8i8bk3b620b6qzhj37jsrhmxxf7wqlsgkifs4k2q8qpf";
+            # google "<game name> logo"
+            icon = builtins.fetchurl {
+              url = "https://www.pngkey.com/png/full/16-160666_rocket-league-png.png";
+              name = "rocket-league.png";
+              sha256 = "09n90zvv8i8bk3b620b6qzhj37jsrhmxxf7wqlsgkifs4k2q8qpf";
+            };
+
+            # if you don't want winediscordipcbridge running for this game
+            discordIntegration = false;
+            # if you dont' want to launch the game using gamemode
+            gamemodeIntegration = false;
+
+            preCommands = ''
+              echo "the game will start!"
+            '';
+
+            postCommands = ''
+              echo "the game has stopped!"
+            '';
           };
-
-          # if you don't want winediscordipcbridge running for this game
-          discordIntegration = false;
-          # if you dont' want to launch the game using gamemode
-          gamemodeIntegration = false;
-
-          preCommands = ''
-            echo "the game will start!"
-          '';
-
-          postCommands = ''
-            the game has stopped!
-          '';
         };
-      };
 
-      opts = {
-        # same options as above can be provided here, and will be applied to all games
-        # NOTE: game-specific options take precedence
-        wine = packages.wine-tkg;
-      };
-    });
+        opts = {
+          # same options as above can be provided here, and will be applied to all games
+          # NOTE: game-specific options take precedence
+          wine = packages.wine-tkg;
+        };
+      });
 }

--- a/flake.lock
+++ b/flake.lock
@@ -11,6 +11,7 @@
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     lib = import ./lib inputs;
 
     # the rest of packages should work automatically
-    apps = lib.forAllSystems (system: {
+    apps = lib.genSystems (system: {
       osu-lazer = {
         program = packages.${system}.osu-lazer-bin.outPath + "/bin/osu-lazer";
         type = "app";
@@ -26,7 +26,7 @@
         pkgs = prev;
       };
 
-    packages = lib.forAllSystems (system: (import ./pkgs {
+    packages = lib.genSystems (system: (import ./pkgs {
       inherit inputs;
       pkgs = import nixpkgs {
         inherit system;

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
 
     nixosModules.pipewireLowLatency = import ./modules/pipewireLowLatency.nix;
     nixosModules.default = inputs.self.nixosModules.pipewireLowLatency;
+
+    formatter = lib.genSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
   };
 
   # auto-fetch deps when `nix run/shell`ing

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,6 @@
 inputs: let
   inherit (inputs.nixpkgs.lib) hasSuffix filesystem genAttrs;
+  pkgs = genSystems (system: import inputs.nixpkgs {inherit system;});
 
   mkPatches = dir:
     map (e: /. + e)
@@ -7,9 +8,7 @@ inputs: let
       (hasSuffix ".patch")
       (filesystem.listFilesRecursive dir));
 
-  forAllSystems = genAttrs supportedSystems;
+  genSystems = genAttrs supportedSystems;
 
   supportedSystems = ["x86_64-linux"];
-in {
-  inherit mkPatches forAllSystems;
-}
+in {inherit mkPatches genSystems;}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2,6 +2,8 @@
   inputs,
   pkgs,
 }: let
+  inherit (pkgs) callPackage;
+
   wineBuilder = wine: build: extra:
     (import ./wine ({
         inherit inputs build pkgs;
@@ -11,27 +13,62 @@
       // extra))
     .${wine};
 
-  inherit (pkgs) callPackage;
-in rec {
-  osu-lazer-bin = callPackage ./osu-lazer-bin {};
+  legendaryBuilder = {
+    games ? {},
+    opts ? {},
+  }:
+    builtins.mapAttrs (
+      name: value:
+        callPackage ./legendary
+        ({
+            inherit (packages) wine-discord-ipc-bridge;
+            pname = name;
+          }
+          // opts
+          // value)
+    )
+    games;
 
-  osu-stable = callPackage ./osu-stable rec {
-    wine = wine-osu;
-    wine-discord-ipc-bridge = callPackage ./wine-discord-ipc-bridge {inherit wine;};
+  packages = rec {
+    osu-lazer-bin = callPackage ./osu-lazer-bin {};
+
+    osu-stable = callPackage ./osu-stable {
+      wine = wine-osu;
+      wine-discord-ipc-bridge = wine-discord-ipc-bridge.override {wine = wine-osu;};
+    };
+
+    technic-launcher = callPackage ./technic-launcher {};
+
+    wine-discord-ipc-bridge = callPackage ./wine-discord-ipc-bridge {wine = wine-tkg;};
+
+    # broken
+    #winestreamproxy = callPackage ./winestreamproxy { wine = wine-tkg; };
+
+    wine-osu = wineBuilder "wine-osu" "base" {};
+
+    wine-tkg = wineBuilder "wine-tkg" "base" {};
+
+    wine-tkg-full = wineBuilder "wine-tkg" "full" {};
+
+    inherit
+      (legendaryBuilder {
+        games = {
+          rocket-league = {
+            desktopName = "Rocket League";
+            tricks = ["dxvk" "win10"];
+            icon = builtins.fetchurl {
+              url = "https://www.pngkey.com/png/full/16-160666_rocket-league-png.png";
+              name = "rocket-league.png";
+              sha256 = "09n90zvv8i8bk3b620b6qzhj37jsrhmxxf7wqlsgkifs4k2q8qpf";
+            };
+            discordIntegration = false;
+          };
+        };
+
+        opts.wine = packages.wine-tkg;
+      })
+      rocket-league
+      ;
   };
-
-  rocket-league = callPackage ./rocket-league {wine = wine-tkg;};
-
-  technic-launcher = callPackage ./technic-launcher {};
-
-  wine-discord-ipc-bridge = callPackage ./wine-discord-ipc-bridge {wine = wine-tkg;};
-
-  # broken
-  #winestreamproxy = callPackage ./winestreamproxy { wine = wine-tkg; };
-
-  wine-osu = wineBuilder "wine-osu" "base" {};
-
-  wine-tkg = wineBuilder "wine-tkg" "base" {};
-
-  wine-tkg-full = wineBuilder "wine-tkg" "full" {};
-}
+in
+  packages

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -13,25 +13,7 @@
       // extra))
     .${wine};
 
-  legendaryBuilder = {
-    games ? {},
-    opts ? {},
-  }:
-    builtins.mapAttrs (
-      name: value:
-        callPackage ./legendary
-        ({
-            inherit (packages) wine-discord-ipc-bridge;
-            pname = name;
-          }
-          // opts
-          // value)
-    )
-    games;
-
   packages = rec {
-    inherit legendaryBuilder;
-
     osu-lazer-bin = callPackage ./osu-lazer-bin {};
 
     osu-stable = callPackage ./osu-stable {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -30,6 +30,8 @@
     games;
 
   packages = rec {
+    inherit legendaryBuilder;
+
     osu-lazer-bin = callPackage ./osu-lazer-bin {};
 
     osu-stable = callPackage ./osu-stable {
@@ -49,26 +51,6 @@
     wine-tkg = wineBuilder "wine-tkg" "base" {};
 
     wine-tkg-full = wineBuilder "wine-tkg" "full" {};
-
-    inherit
-      (legendaryBuilder {
-        games = {
-          rocket-league = {
-            desktopName = "Rocket League";
-            tricks = ["dxvk" "win10"];
-            icon = builtins.fetchurl {
-              url = "https://www.pngkey.com/png/full/16-160666_rocket-league-png.png";
-              name = "rocket-league.png";
-              sha256 = "09n90zvv8i8bk3b620b6qzhj37jsrhmxxf7wqlsgkifs4k2q8qpf";
-            };
-            discordIntegration = false;
-          };
-        };
-
-        opts.wine = packages.wine-tkg;
-      })
-      rocket-league
-      ;
   };
 in
   packages

--- a/pkgs/legendary/default.nix
+++ b/pkgs/legendary/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  makeDesktopItem,
+  symlinkJoin,
+  writeShellScriptBin,
+  gamemode,
+  legendary-gl,
+  wine,
+  winetricks,
+  wine-discord-ipc-bridge,
+  desktopName ? "",
+  icon ? null,
+  location ? "$HOME/Games/${desktopName}",
+  meta ? {},
+  pname ? "",
+  tricks ? [],
+  wineFlags ? "",
+  preCommands ? "",
+  postCommands ? "",
+  discordIntegration ? true,
+  gamemodeIntegration ? true,
+}: let
+  # concat winetricks args
+  tricksString = with builtins;
+    if (length tricks) > 0
+    then concatStringsSep " " tricks
+    else "-V";
+
+  script = writeShellScriptBin pname ''
+    export DXVK_HUD=compiler
+    export WINEESYNC=1
+    export WINEFSYNC=1
+    export WINEPREFIX="${location}"
+
+    PATH=${wine}/bin:${winetricks}/bin:${legendary-gl}/bin:$PATH
+
+    if [ ! -d "$WINEPREFIX" ]; then
+      # install tricks
+      winetricks -q ${tricksString}
+      wineserver -k
+    fi
+
+    ${preCommands}
+
+    legendary update "${desktopName}" --base-path "${location}"
+    ${lib.optionalString discordIntegration "wine ${wine-discord-ipc-bridge}/bin/winediscordipcbridge.exe &"}
+    ${lib.optionalString gamemodeIntegration "${gamemode}/bin/gamemoderun"} legendary launch "${desktopName}" --base-path "${location}"
+    wineserver -w
+
+    ${postCommands}
+  '';
+
+  desktopItems = makeDesktopItem {
+    exec = "${script}/bin/${pname}";
+    inherit icon desktopName;
+    name = pname;
+    categories = ["Game"];
+  };
+in
+  symlinkJoin {
+    name = pname;
+    paths = [desktopItems script];
+
+    inherit meta;
+  }

--- a/pkgs/osu-lazer-bin/default.nix
+++ b/pkgs/osu-lazer-bin/default.nix
@@ -99,6 +99,7 @@ in
         cc-by-nc-40
         unfreeRedistributable # osu-framework contains libbass.so in repository
       ];
+      mainProgram = "osu-lazer";
       platforms = ["x86_64-linux"];
     };
   }

--- a/pkgs/wine/default.nix
+++ b/pkgs/wine/default.nix
@@ -90,7 +90,7 @@ in {
         };
         patches = ["${inputs.nixpkgs}/pkgs/applications/emulators/wine/cert-path.patch"] ++ inputs.self.lib.mkPatches ./patches;
       }))
-    .overrideDerivation (self: {
+    .overrideDerivation (_: {
       prePatch = ''
         patchShebangs tools
         cp -r ${staging}/patches .


### PR DESCRIPTION
I envisioned some kind of function that would take a set of games and declaratively install them, for `legendary`. Currently, there's only `rocket-league` available in this repo, but I wanted to extend the functionality to potentially any game that legendary supports.

The config the user is supposed to write to get the games installed is a bit more verbose than it used to be, but it should make it easier to install games not listed in this repo. I've also tried keeping the options sane and minimal, but there are plenty of options for extending functionality.

Aside from the new `legendaryBuilder`, I've also took the time to apply some stylistic changes to the repo, such as using a single `pkgs` instance for both the builder and the normal `packages`.

Let me know if you have any ideas on how this can be improved.