### PR TITLE
Fix invalid meta

### DIFF
--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -80,7 +80,7 @@ in
       description = "osu!stable installer and runner";
       homepage = "https://osu.ppy.sh";
       license = lib.licenses.unfree;
-      maintainer = with lib.maintainers; [fufexan];
+      maintainers = with lib.maintainers; [fufexan];
       platforms = with lib.platforms; ["x86_64-linux"];
     };
   }


### PR DESCRIPTION
Otherwise we get the following error:

```
error: Package ‘osu-stable’ in /nix/store/nwffh179bzszwry8syj74l4qw6m13aq2-source/pkgs/osu-stable/default.nix:80 has an invalid meta attrset:
       	- key 'meta.maintainer' is unrecognized; expected one of:
       	     ['available', 'badPlatforms', 'branch', 'broken', 'changelog', 'description', 'downloadPage', 'executables', 'homepage', 'hydraPlatforms', 'insecure', 'isBuildPythonPackage', 'isFcitxEngine', 'isGutenprint', 'isHydraChannel', 'isIbusEngine', 'knownVulnerabilities', 'license', 'longDescription', 'mainProgram', 'maintainers', 'maxSilent', 'name', 'outputsToInstall', 'platforms', 'position', 'priority', 'schedulingPriority', 'sourceProvenance', 'tag', 'tests', 'timeout', 'unfree', 'unsupported', 'version'], refusing to evaluate.
```