### PR TITLE
roblox-player: update .desktop icon sha

### DIFF
--- a/pkgs/roblox-player/default.nix
+++ b/pkgs/roblox-player/default.nix
@@ -23,7 +23,7 @@
   };
   icon = builtins.fetchurl {
     url = "https://static.wikia.nocookie.net/logopedia/images/1/1e/Roblox_2022_%28Icon%29.png/revision/latest/scale-to-width-down/200?cb=20220831193228";
-    name = "roblox-player.png";
+    name = "roblox-player-${sha}.png";
     sha256 = "0gjkzcs05l45034q7g6r7s1983pkx83wgynqdabgdvh03jh1wx0j";
   };
 

--- a/pkgs/roblox-player/default.nix
+++ b/pkgs/roblox-player/default.nix
@@ -24,7 +24,7 @@
   icon = builtins.fetchurl {
     url = "https://static.wikia.nocookie.net/logopedia/images/1/1e/Roblox_2022_%28Icon%29.png/revision/latest/scale-to-width-down/200?cb=20220831193228";
     name = "roblox-player.png";
-    sha256 = "0a40sp5va7bfnkwdq9ass22d72ssmfsr3b2861204rbc8salhabg";
+    sha256 = "0gjkzcs05l45034q7g6r7s1983pkx83wgynqdabgdvh03jh1wx0j";
   };
 
   # concat winetricks args


### PR DESCRIPTION
Untested. Firefox says the new image is a WebP, which might break things if it wasn't before.

Would it be a good idea to host these .desktop icons in some place less volatile than a wiki?