### PR TITLE
Update pkgs.osu-stable sha256

### DIFF
--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -17,7 +17,7 @@
   src = builtins.fetchurl rec {
     url = "https://m1.ppy.sh/r/osu!install.exe";
     name = "osuinstall-${sha256}.exe";
-    sha256 = "1pfj2jnf9vxmbw48v5kv060h66awn8sr67cfzp534lrc2qi54kkg";
+    sha256 = "06m59s8zrkizjg7kbi3warrl32fdgbrs2xdys2bpzz9wrx5bsmxd";
   };
   icon = builtins.fetchurl {
     # original url = "https://i.ppy.sh/013ed2c11b34720790e74035d9f49078d5e9aa64/68747470733a2f2f6f73752e7070792e73682f77696b692f696d616765732f4272616e645f6964656e746974795f67756964656c696e65732f696d672f75736167652d66756c6c2d636f6c6f75722e706e67";


### PR DESCRIPTION
Peppy updated the `osu!install.exe` file again, thus breaking installing the packages.

This PR updates the `sha256` property in `pkgs/osu-stable/default.nix` to be the latest one.