### PR TITLE
flake: use flake-parts

### DIFF
--- a/example.nix
+++ b/example.nix
@@ -9,10 +9,8 @@
       # ...
     ]
     # construct a list from the output attrset
-    ++ builtins.attrValues (inputs.nix-gaming.lib.legendaryBuilder
+    ++ (inputs.nix-gaming.lib.legendaryBuilder pkgs
       {
-        inherit (pkgs) system;
-
         games = {
           rocket-league = {
             # find names with `legendary list`

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1675933616,
+        "narHash": "sha256-/rczJkJHtx16IFxMmAWu5nNYcSXNg1YYXTHoGjLrLUA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "47478a4a003e745402acf63be7f9a092d51b83d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1681753173,
@@ -16,8 +34,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1675183161,
+        "narHash": "sha256-Zq8sNgAxDckpn7tJo7V1afRSk2eoVbu3OjI1QklGLNg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e1e1b192c1a5aab2960bf0a0bd53a2e8124fa18e",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -9,21 +9,20 @@
           (hasSuffix ".patch")
           (filesystem.listFilesRecursive dir));
 
-  legendaryBuilder = {
-    games ? {},
-    opts ? {},
-    system ? "",
-  }:
-    builtins.mapAttrs (
-      name: value:
-        pkgs.${system}.callPackage ../pkgs/legendary
-        ({
-            inherit (inputs.self.packages.${system}) wine-discord-ipc-bridge;
-            pname = name;
-          }
-          // opts
-          // value)
-    )
-    games;
+    legendaryBuilder = pkgs: {
+      games ? {},
+      opts ? {},
+    }:
+      builtins.attrValues (builtins.mapAttrs (
+          name: value:
+            pkgs.callPackage ../pkgs/legendary
+            ({
+                inherit (inputs.self.packages.${pkgs.hostPlatform.system}) wine-discord-ipc-bridge;
+                pname = name;
+              }
+              // opts
+              // value)
+        )
+        games);
   };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,20 +1,13 @@
-inputs: let
-  inherit (inputs.nixpkgs.lib) hasSuffix filesystem genAttrs;
-
-  pkgs = genSystems (system:
-    import inputs.nixpkgs
-    {
-      inherit system;
-      config.allowUnfree = true;
-    });
-
-  mkPatches = dir:
-    map (e: /. + e)
-    (builtins.filter
-      (hasSuffix ".patch")
-      (filesystem.listFilesRecursive dir));
-
-  genSystems = genAttrs supportedSystems;
+{inputs, ...}: {
+  flake.lib = {
+    mkPatches = let
+      inherit (inputs.nixpkgs.lib) hasSuffix filesystem;
+    in
+      dir:
+        map (e: /. + e)
+        (builtins.filter
+          (hasSuffix ".patch")
+          (filesystem.listFilesRecursive dir));
 
   legendaryBuilder = {
     games ? {},
@@ -32,6 +25,5 @@ inputs: let
           // value)
     )
     games;
-
-  supportedSystems = ["x86_64-linux"];
-in {inherit mkPatches genSystems legendaryBuilder pkgs;}
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,62 +1,76 @@
 {
   inputs,
-  pkgs,
-}: let
-  inherit (pkgs) callPackage;
-  pins = import ../npins;
+  self,
+  ...
+}: {
+  systems = ["x86_64-linux"];
 
-  wineBuilder = wine: build: extra:
-    (import ./wine ({
-        inherit inputs build pkgs pins;
-        inherit (pkgs) callPackage fetchFromGitHub fetchurl lib autoconf perl moltenvk hexdump pkgsCross pkgsi686Linux stdenv_32bit;
-        supportFlags = (import ./wine/supportFlags.nix).${build};
-      }
-      // extra))
-    .${wine};
+  imports = [inputs.flake-parts.flakeModules.easyOverlay];
 
-  packages = rec {
-    dxvk = callPackage ./dxvk {inherit pins;};
-    dxvk-w32 = pkgs.pkgsCross.mingw32.callPackage ./dxvk {inherit pins;};
-    dxvk-w64 = pkgs.pkgsCross.mingwW64.callPackage ./dxvk {inherit pins;};
-
-    faf-client = callPackage ./faf-client {};
-    faf-client-unstable = callPackage ./faf-client {unstable = true;};
-
-    osu-lazer-bin = callPackage ./osu-lazer-bin {inherit pins;};
-
-    osu-stable = callPackage ./osu-stable {
-      wine = wine-osu;
-      wine-discord-ipc-bridge = wine-discord-ipc-bridge.override {wine = wine-osu;};
+  perSystem = {
+    config,
+    system,
+    pkgs,
+    ...
+  }: {
+    _module.args.pkgs = import inputs.nixpkgs {
+      inherit system;
+      config.allowUnfree = true;
     };
 
-    proton-ge = callPackage ./proton-ge {};
+    packages = let
+      pins = import ../npins;
 
-    roblox-player = callPackage ./roblox-player {
-      wine = wine-tkg;
-      inherit wine-discord-ipc-bridge;
+      wineBuilder = wine: build: extra:
+        (import ./wine ({
+            inherit inputs self pkgs build pins;
+            inherit (pkgs) callPackage fetchFromGitHub fetchurl lib moltenvk pkgsCross pkgsi686Linux stdenv_32bit;
+            supportFlags = (import ./wine/supportFlags.nix).${build};
+          }
+          // extra))
+        .${wine};
+    in {
+      dxvk = pkgs.callPackage ./dxvk {inherit pins;};
+      dxvk-w32 = pkgs.pkgsCross.mingw32.callPackage ./dxvk {inherit pins;};
+      dxvk-w64 = pkgs.pkgsCross.mingwW64.callPackage ./dxvk {inherit pins;};
+
+      faf-client = pkgs.callPackage ./faf-client {};
+      faf-client-unstable = pkgs.callPackage ./faf-client {unstable = true;};
+
+      osu-lazer-bin = pkgs.callPackage ./osu-lazer-bin {inherit pins;};
+
+      osu-stable = pkgs.callPackage ./osu-stable {
+        wine = config.packages.wine-osu;
+        wine-discord-ipc-bridge = config.packages.wine-discord-ipc-bridge.override {wine = config.packages.wine-osu;};
+      };
+
+      proton-ge = pkgs.callPackage ./proton-ge {};
+      roblox-player = pkgs.callPackage ./roblox-player {
+        wine = config.packages.wine-tkg;
+        inherit (config.packages) wine-discord-ipc-bridge;
+      };
+
+      technic-launcher = pkgs.callPackage ./technic-launcher {};
+
+      vkd3d-proton = pkgs.callPackage ./vkd3d-proton {inherit pins;};
+      vkd3d-proton-w32 = pkgs.pkgsCross.mingw32.callPackage ./vkd3d-proton {inherit pins;};
+      vkd3d-proton-w64 = pkgs.pkgsCross.mingwW64.callPackage ./vkd3d-proton {inherit pins;};
+
+      wine-discord-ipc-bridge = pkgs.callPackage ./wine-discord-ipc-bridge {
+        inherit pins;
+        wine = config.packages.wine-tkg;
+      };
+
+      # broken
+      #winestreamproxy = callPackage ./winestreamproxy { wine = wine-tkg; };
+
+      wine-ge = wineBuilder "wine-ge" "full" {};
+
+      wine-osu = wineBuilder "wine-osu" "base" {};
+
+      wine-tkg = wineBuilder "wine-tkg" "full" {};
+
+      wineprefix-preparer = pkgs.callPackage ./wineprefix-preparer {inherit (config.packages) dxvk-w32 vkd3d-proton-w32 dxvk-w64 vkd3d-proton-w64;};
     };
-
-    technic-launcher = callPackage ./technic-launcher {};
-
-    vkd3d-proton = callPackage ./vkd3d-proton {inherit pins;};
-    vkd3d-proton-w32 = pkgs.pkgsCross.mingw32.callPackage ./vkd3d-proton {inherit pins;};
-    vkd3d-proton-w64 = pkgs.pkgsCross.mingwW64.callPackage ./vkd3d-proton {inherit pins;};
-
-    wine-discord-ipc-bridge = callPackage ./wine-discord-ipc-bridge {
-      inherit pins;
-      wine = wine-tkg;
-    };
-
-    # broken
-    #winestreamproxy = callPackage ./winestreamproxy { wine = wine-tkg; };
-
-    wine-ge = wineBuilder "wine-ge" "full" {};
-
-    wine-osu = wineBuilder "wine-osu" "base" {};
-
-    wine-tkg = wineBuilder "wine-tkg" "full" {};
-
-    wineprefix-preparer = callPackage ./wineprefix-preparer {inherit dxvk-w32 vkd3d-proton-w32 dxvk-w64 vkd3d-proton-w64;};
   };
-in
-  packages
+}

--- a/pkgs/wine/default.nix
+++ b/pkgs/wine/default.nix
@@ -1,5 +1,6 @@
 {
   inputs,
+  self,
   pins,
   lib,
   build,
@@ -9,10 +10,7 @@
   callPackage,
   fetchFromGitHub,
   fetchurl,
-  autoconf,
-  perl,
   moltenvk,
-  hexdump,
   supportFlags,
   stdenv_32bit,
 }: let
@@ -67,10 +65,10 @@ in {
           rev = "wine-${version}";
           sha256 = "sha256-uDdjgibNGe8m1EEL7LGIkuFd1UUAFM21OgJpbfiVPJs=";
         };
-        patches = ["${inputs.nixpkgs}/pkgs/applications/emulators/wine/cert-path.patch"] ++ inputs.self.lib.mkPatches ./patches;
+        patches = ["${inputs.nixpkgs}/pkgs/applications/emulators/wine/cert-path.patch"] ++ self.lib.mkPatches ./patches;
       }))
     .overrideDerivation (old: {
-      nativeBuildInputs = [autoconf perl hexdump] ++ old.nativeBuildInputs;
+      nativeBuildInputs = with pkgs; [autoconf perl hexdump] ++ old.nativeBuildInputs;
       prePatch = ''
         patchShebangs tools
         cp -r ${staging}/patches .


### PR DESCRIPTION
Not a necessary feature but it is easier to integrate into a framework used by
many.

legendary-builder: simplify by making it a function
NOTICE: now legendary-builder requires a `pkgs` argument, and no longer depends
on a `system` key being present!
