### PR TITLE
faf-client: sort github releases chronologically

### DIFF
--- a/pkgs/faf-client/default.nix
+++ b/pkgs/faf-client/default.nix
@@ -21,8 +21,8 @@
     sha256 = sha256Stable;
   };
 
-  versionUnstable = "2023.2.0-alpha-3";
-  sha256Unstable = "132xwqphl5wxqrndsdxa77m9k27zpzllyxp12rabshwk8m0p4ji7";
+  versionUnstable = "2023.2.0";
+  sha256Unstable = "1cchix8n3iy744hbr61dj5wkdv6ydg46ims6cmp6ydyb1wc0l281";
   srcUnstable = builtins.fetchTarball {
     url = "https://github.com/FAForever/downlords-faf-client/releases/download/v${versionUnstable}/faf_unix_${builtins.replaceStrings ["."] ["_"] versionUnstable}.tar.gz";
     sha256 = sha256Unstable;

--- a/pkgs/faf-client/update.sh
+++ b/pkgs/faf-client/update.sh
@@ -4,6 +4,15 @@ set -euo pipefail
 
 filePath="pkgs/faf-client/default.nix"
 
+dry_run=
+while test $# != 0
+do
+    case "$1" in
+    -d|--dry-run) dry_run=1 ;;
+    esac
+    shift
+done
+
 # get string variable contents from the nix file
 function getValue()
 {
@@ -13,21 +22,30 @@ function calcHash()
 {
     (nix-build --no-out-link -A "$1" || true) |& grep --perl-regexp --only-matching 'got: +.+[:-]\K.+'
 }
+function replaceInFile()
+{
+    if [ -n "$dry_run" ]; then
+        echo "will replace "'`'"$1"'`'" with "'`'"$2"'`'
+    else
+        sed -i "s/$1/$2/g" "$filePath"
+    fi
+}
 
-releaseData="$(curl -s https://api.github.com/repos/FAForever/downlords-faf-client/releases)"
+releaseData="$(curl -s https://api.github.com/repos/FAForever/downlords-faf-client/releases | cat -v | tr '\n' ' ')"
 
 versionStable="$(
     echo "$releaseData" |
     jq '.[] | select(.prerelease!=true) | .tag_name' --raw-output |
-    sort --version-sort --reverse |
     head -n1 | tail -c +2
 )"
 versionUnstable="$(
     echo "$releaseData" |
     jq '.[] | .tag_name' --raw-output |
-    sort --version-sort --reverse |
     head -n1 | tail -c +2
 )"
+
+echo "Stable version: $versionStable"
+echo "Unstable version: $versionUnstable"
 
 system=$(nix-instantiate --eval -E 'builtins.currentSystem' | tr -d '"')
 
@@ -45,11 +63,13 @@ else
 
     # this might update the unstable version, and that's intended
     # in case there's no unstable version right now
-    sed -i "s/$oldVersionStable/$versionStable/g" $filePath
+    replaceInFile "$oldVersionStable" "$versionStable"
 
-    sed -i "s/$oldSha256Stable/$fakeSha256_1/g" $filePath
-    sha256Stable=$(calcHash "packages.$system.faf-client")
-    sed -i "s/$fakeSha256_1/$sha256Stable/g" $filePath
+    replaceInFile "$oldSha256Stable" "$fakeSha256_1"
+    if [ -z "$dry_run" ]; then
+        sha256Stable=$(calcHash "packages.$system.faf-client")
+        replaceInFile "$fakeSha256_1" "$sha256Stable"
+    fi
 fi
 
 oldVersionUnstable=$(getValue versionUnstable)
@@ -59,11 +79,13 @@ if [[ "$oldVersionUnstable" = "$versionUnstable" ]]; then
     echo "no unstable faf updates"
 else
     echo "updating unstable: $oldVersionUnstable->$versionUnstable"
-    sed -i "s/versionUnstable = \"$oldVersionUnstable/versionUnstable = \"$versionUnstable/g" $filePath
+    replaceInFile "versionUnstable = \"$oldVersionUnstable" "versionUnstable = \"$versionUnstable"
 
-    sed -i "s/sha256Unstable = \"$oldSha256Unstable/sha256Unstable = \"$fakeSha256_2/g" $filePath
-    sha256Unstable=$(calcHash "packages.$system.faf-client-unstable")
-    sed -i "s/$fakeSha256_2/$sha256Unstable/g" $filePath
+    replaceInFile "sha256Unstable = \"$oldSha256Unstable" "sha256Unstable = \"$fakeSha256_2"
+    if [ -z "$dry_run" ]; then
+        sha256Unstable=$(calcHash "packages.$system.faf-client-unstable")
+        replaceInFile "$fakeSha256_2" "$sha256Unstable" $filePath
+    fi
 fi
 
 echo "done!"


### PR DESCRIPTION
Now releases will be considered newer than alpha versions for the purposes of automatic update check.

As a bonus, this fixes `jq` having trouble with Github's malformed json API returning unescaped strings.