### PR TITLE
osu-lazer-bin: add vulkan-loader to deps

### DIFF
--- a/pkgs/osu-lazer-bin/default.nix
+++ b/pkgs/osu-lazer-bin/default.nix
@@ -18,6 +18,7 @@
   stdenvNoCC,
   symlinkJoin,
   writeShellScript,
+  vulkan-loader,
   pipewire_latency ? "64/48000", # reasonable default
   gmrun_enable ? true, # won't hurt users even if they don't have it set up
 }: let
@@ -45,6 +46,7 @@
       lttng-ust
       numactl
       openssl
+      vulkan-loader
     ];
     nativeBuildInputs = [
       autoPatchelfHook


### PR DESCRIPTION
As the Vulkan (Veldrid) renderer was recently merged into osu!lazer (as broken as it is), to use it we need to add a new dependency for the package. This commit does that.