### PR TITLE
wine-osu: fix build with recent commits of nixpkgs-unstable

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -8,7 +8,7 @@
   wineBuilder = wine: build: extra:
     (import ./wine ({
         inherit inputs build pkgs pins;
-        inherit (pkgs) callPackage fetchFromGitHub fetchurl lib moltenvk pkgsCross pkgsi686Linux stdenv_32bit;
+        inherit (pkgs) callPackage fetchFromGitHub fetchurl lib autoconf perl moltenvk hexdump pkgsCross pkgsi686Linux stdenv_32bit;
         supportFlags = (import ./wine/supportFlags.nix).${build};
       }
       // extra))

--- a/pkgs/wine/default.nix
+++ b/pkgs/wine/default.nix
@@ -9,7 +9,10 @@
   callPackage,
   fetchFromGitHub,
   fetchurl,
+  autoconf,
+  perl,
   moltenvk,
+  hexdump,
   supportFlags,
   stdenv_32bit,
 }: let
@@ -66,7 +69,8 @@ in {
         };
         patches = ["${inputs.nixpkgs}/pkgs/applications/emulators/wine/cert-path.patch"] ++ inputs.self.lib.mkPatches ./patches;
       }))
-    .overrideDerivation (_: {
+    .overrideDerivation (old: {
+      nativeBuildInputs = [autoconf perl hexdump] ++ old.nativeBuildInputs;
       prePatch = ''
         patchShebangs tools
         cp -r ${staging}/patches .


### PR DESCRIPTION
Example of the issue:

```
$ nix build .\#packages.x86_64-linux.wine-osu --override-input nixpkgs github:NixOS/nixpkgs/nixos-unstable
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a1240f6b4a0bcc84fc48008b396a140d9f3638f6' (2023-03-05)
  → 'github:NixOS/nixpkgs/9c8ff8b426a8b07b9e0a131ac3218740dc85ba1e' (2023-04-05)
error: builder for '/nix/store/3fxji15bzc28h8ka1v5b7xa1w5677w2b-wine-osu-7.0.drv' failed with exit code 1;
       last 10 log lines:
       > tools/install-sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/0hx32wk55ml88jrb1qxwg5c5yazfm6gf-bash-5.2-p15/bin/sh"
       > tools/findfunc: interpreter directive changed from "#!/bin/sh" to "/nix/store/0hx32wk55ml88jrb1qxwg5c5yazfm6gf-bash-5.2-p15/bin/sh"
       > tools/config.sub: interpreter directive changed from "#! /bin/sh" to "/nix/store/0hx32wk55ml88jrb1qxwg5c5yazfm6gf-bash-5.2-p15/bin/sh"
       > tools/config.guess: interpreter directive changed from "#! /bin/sh" to "/nix/store/0hx32wk55ml88jrb1qxwg5c5yazfm6gf-bash-5.2-p15/bin/sh"
       > patching script interpreter paths in gitapply.sh
       > gitapply.sh: interpreter directive changed from "#!/usr/bin/env bash" to "/nix/store/0hx32wk55ml88jrb1qxwg5c5yazfm6gf-bash-5.2-p15/bin/bash"
       > Applying /build/source/patches/Compiler_Warnings/0001-windowscodecs-Avoid-implicit-cast-of-interface-point.patch
       > Missing dependency: hexdump - please install this program and try again.
       > ERROR: Failed to apply patch, aborting!
       > /nix/store/b49g58nnzaczm04s0hildd4zai2jrzxf-stdenv-linux/setup: line 136: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/3fxji15bzc28h8ka1v5b7xa1w5677w2b-wine-osu-7.0.drv'.
```

Adding `hexdump` to `nativeBuildInputs` results in another error:

```
       > ./patchinstall.sh: line 961: autoreconf: not found
       > ERROR: 'autoreconf -f' failed.
```

And adding `autoconf` to `nativeBuildInputs` results in yet another error:

```
       > ./patchinstall.sh: line 994: ./tools/make_requests: not found
       > ERROR: './tools/make_requests' failed.
```

This last error is because `./tools/make_requests` is a Perl script and there is no Perl in the environment. Adding `perl` to `nativeBuildInputs` allows `wine-osu` to build again.

Since we are just adding a few tools in `nativeBuildInputs`, this should not cause older versions of nixpkgs to break, so this should be backwards compatible.