### PR TITLE
 wine-ge: Proton7-42 -> Proton7-43

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677995890,
-        "narHash": "sha256-eOnCn0o3I6LP48fAi8xWFcn49V2rL7oX5jCtJTeN1LI=",
+        "lastModified": 1681753173,
+        "narHash": "sha256-MrGmzZWLUqh2VstoikKLFFIELXm/lsf/G9U9zR96VD4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1240f6b4a0bcc84fc48008b396a140d9f3638f6",
+        "rev": "0a4206a51b386e5cda731e8ac78d76ad924c7125",
         "type": "github"
       },
       "original": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -49,10 +49,10 @@
         "owner": "GloriousEggroll",
         "repo": "proton-wine"
       },
-      "branch": "Proton7-42",
-      "revision": "9ee5c1b71ee160877dcf8bd3a927ca7e27751cd5",
-      "url": "https://github.com/GloriousEggroll/proton-wine/archive/9ee5c1b71ee160877dcf8bd3a927ca7e27751cd5.tar.gz",
-      "hash": "0i4lykczsqf6yyk6zbjgk3n9v8x9mgby527v0bh2hbzq83mxkfj1"
+      "branch": "Proton7-43",
+      "revision": "e9a47cbabb94d94ce03a5e7c0774e8fbf741aa96",
+      "url": "https://github.com/GloriousEggroll/proton-wine/archive/e9a47cbabb94d94ce03a5e7c0774e8fbf741aa96.tar.gz",
+      "hash": "0c9l29ccra770iqdiq7x1b8ygi78v5rz9b6rmzpsxy0pzp41pf8f"
     },
     "vkd3d-proton": {
       "type": "GitRelease",


### PR DESCRIPTION
Also update flake.lock.
Currently, the game I was playing (Rise of the Tomb Raider) doesn't launch after I updated NixOS. With this, it launches again.