### PR TITLE
add proton-ge derivation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         - wine-osu
         - wine-ge
         - wine-tkg
+        - proton-ge
     steps:
       - uses: actions/checkout@v3.0.2
       - uses: cachix/install-nix-action@v20

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Package                   | Description
 `wine-osu`                | Wine optimized for low latency
 `wine-tkg`                | Wine optimized for games
 `winestreamproxy`         | Wine-Discord RPC (broken)
+`proton-ge`               | Custom build of Proton with the most recent bleeding-edge Proton Experimental WINE
 
 * To run FAF, first run Supreme Commander: Forged Alliance via Steam normally at
 least once. After you make sure it works, run `faf-client-setup` to set up the
@@ -64,6 +65,9 @@ It consists of a wine tree generated with
 
 * `winestreamproxy` provides bridging between games under Wine and Discord
 running on Linux. (**currently broken, help with building would be appreciated**)
+
+* To use `proton-ge`, you must add it to your steam compatibility tools path.
+More info can be found [here](https://github.com/NixOS/nixpkgs/issues/73323#issuecomment-1079939987).
 
 ## Install & Run
 

--- a/npins/default.nix
+++ b/npins/default.nix
@@ -6,62 +6,42 @@ let
   mkSource = spec:
     assert spec ? type; let
       path =
-        if spec.type == "Git"
-        then mkGitSource spec
-        else if spec.type == "GitRelease"
-        then mkGitSource spec
-        else if spec.type == "PyPi"
-        then mkPyPiSource spec
-        else if spec.type == "Channel"
-        then mkChannelSource spec
+        if spec.type == "Git" then mkGitSource spec
+        else if spec.type == "GitRelease" then mkGitSource spec
+        else if spec.type == "PyPi" then mkPyPiSource spec
+        else if spec.type == "Channel" then mkChannelSource spec
         else builtins.throw "Unknown source type ${spec.type}";
     in
-      spec // {outPath = path;};
+    spec // { outPath = path; };
 
-  mkGitSource = {
-    repository,
-    revision,
-    url ? null,
-    hash,
-    ...
-  }:
+  mkGitSource = { repository, revision, url ? null, hash, ... }:
     assert repository ? type;
     # At the moment, either it is a plain git repository (which has an url), or it is a GitHub/GitLab repository
     # In the latter case, there we will always be an url to the tarball
-      if url != null
-      then
-        (builtins.fetchTarball {
-          inherit url;
-          sha256 = hash; # FIXME: check nix version & use SRI hashes
-        })
-      else
-        assert repository.type == "Git";
-          builtins.fetchGit {
-            url = repository.url;
-            rev = revision;
-            # hash = hash;
-          };
+    if url != null then
+      (builtins.fetchTarball {
+        inherit url;
+        sha256 = hash; # FIXME: check nix version & use SRI hashes
+      })
+    else assert repository.type == "Git"; builtins.fetchGit {
+      url = repository.url;
+      rev = revision;
+      # hash = hash;
+    };
 
-  mkPyPiSource = {
-    url,
-    hash,
-    ...
-  }:
+  mkPyPiSource = { url, hash, ... }:
     builtins.fetchurl {
       inherit url;
       sha256 = hash;
     };
 
-  mkChannelSource = {
-    url,
-    hash,
-    ...
-  }:
+  mkChannelSource = { url, hash, ... }:
     builtins.fetchTarball {
       inherit url;
       sha256 = hash;
     };
 in
-  if version == 3
-  then builtins.mapAttrs (_: mkSource) data.pins
-  else throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"
+if version == 3 then
+  builtins.mapAttrs (_: mkSource) data.pins
+else
+  throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/npins/default.nix
+++ b/npins/default.nix
@@ -6,42 +6,62 @@ let
   mkSource = spec:
     assert spec ? type; let
       path =
-        if spec.type == "Git" then mkGitSource spec
-        else if spec.type == "GitRelease" then mkGitSource spec
-        else if spec.type == "PyPi" then mkPyPiSource spec
-        else if spec.type == "Channel" then mkChannelSource spec
+        if spec.type == "Git"
+        then mkGitSource spec
+        else if spec.type == "GitRelease"
+        then mkGitSource spec
+        else if spec.type == "PyPi"
+        then mkPyPiSource spec
+        else if spec.type == "Channel"
+        then mkChannelSource spec
         else builtins.throw "Unknown source type ${spec.type}";
     in
-    spec // { outPath = path; };
+      spec // {outPath = path;};
 
-  mkGitSource = { repository, revision, url ? null, hash, ... }:
+  mkGitSource = {
+    repository,
+    revision,
+    url ? null,
+    hash,
+    ...
+  }:
     assert repository ? type;
     # At the moment, either it is a plain git repository (which has an url), or it is a GitHub/GitLab repository
     # In the latter case, there we will always be an url to the tarball
-    if url != null then
-      (builtins.fetchTarball {
-        inherit url;
-        sha256 = hash; # FIXME: check nix version & use SRI hashes
-      })
-    else assert repository.type == "Git"; builtins.fetchGit {
-      url = repository.url;
-      rev = revision;
-      # hash = hash;
-    };
+      if url != null
+      then
+        (builtins.fetchTarball {
+          inherit url;
+          sha256 = hash; # FIXME: check nix version & use SRI hashes
+        })
+      else
+        assert repository.type == "Git";
+          builtins.fetchGit {
+            url = repository.url;
+            rev = revision;
+            # hash = hash;
+          };
 
-  mkPyPiSource = { url, hash, ... }:
+  mkPyPiSource = {
+    url,
+    hash,
+    ...
+  }:
     builtins.fetchurl {
       inherit url;
       sha256 = hash;
     };
 
-  mkChannelSource = { url, hash, ... }:
+  mkChannelSource = {
+    url,
+    hash,
+    ...
+  }:
     builtins.fetchTarball {
       inherit url;
       sha256 = hash;
     };
 in
-if version == 3 then
-  builtins.mapAttrs (_: mkSource) data.pins
-else
-  throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"
+  if version == 3
+  then builtins.mapAttrs (_: mkSource) data.pins
+  else throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -28,7 +28,7 @@
       wine = wine-osu;
       wine-discord-ipc-bridge = wine-discord-ipc-bridge.override {wine = wine-osu;};
     };
-    
+
     proton-ge = callPackage ./proton-ge {};
 
     roblox-player = callPackage ./roblox-player {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -28,6 +28,8 @@
       wine = wine-osu;
       wine-discord-ipc-bridge = wine-discord-ipc-bridge.override {wine = wine-osu;};
     };
+    
+    proton-ge = callPackage ./proton-ge {};
 
     roblox-player = callPackage ./roblox-player {
       wine = wine-tkg;

--- a/pkgs/proton-ge/default.nix
+++ b/pkgs/proton-ge/default.nix
@@ -2,24 +2,15 @@
   stdenv,
   lib,
   fetchurl,
-  writeScript,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  name = "proton-ge-custom";
-  version = "GE-Proton8-2";
+  pname = "proton-ge-custom";
+  version = "GE-Proton8-3";
 
   src = fetchurl {
     url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-gof4yL5sHPKXDC4mDfPyBIvPtWxxxVy6gHx58yoTEbQ=";
+    hash = "sha256-JYGwb0LhIs6B2/OHiU+mJ/dAAS+Dg+MrVksAsn6IS9g=";
   };
-
-  passthru.updateScript = writeScript "update-pytr" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl jq common-updater-scripts
-
-    version="$(curl -sL "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases" | jq 'map(select(.prerelease == false)) | .[0].tag_name' --raw-output)"
-    update-source-version proton-ge-custom "$version"
-  '';
 
   buildCommand = ''
     mkdir -p $out/bin
@@ -30,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Compatibility tool for Steam Play based on Wine and additional components";
     homepage = "https://github.com/GloriousEggroll/proton-ge-custom";
     license = licenses.bsd3;
-    platforms = ["x86_64-linux"];
     maintainers = with maintainers; [notashelf];
+    platforms = ["x86_64-linux"];
   };
 })

--- a/pkgs/proton-ge/default.nix
+++ b/pkgs/proton-ge/default.nix
@@ -1,0 +1,36 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  name = "proton-ge-custom";
+  version = "GE-Proton8-2";
+
+  src = fetchurl {
+    url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
+    sha256 = "sha256-gof4yL5sHPKXDC4mDfPyBIvPtWxxxVy6gHx58yoTEbQ=";
+  };
+
+  passthru.updateScript = writeScript "update-pytr" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+
+    version="$(curl -sL "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases" | jq 'map(select(.prerelease == false)) | .[0].tag_name' --raw-output)"
+    update-source-version proton-ge-custom "$version"
+  '';
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    tar -C $out/bin --strip=1 -x -f $src
+  '';
+
+  meta = with lib; {
+    description = "Compatibility tool for Steam Play based on Wine and additional components";
+    homepage = "https://github.com/GloriousEggroll/proton-ge-custom";
+    license = licenses.bsd3;
+    platforms = ["x86_64-linux"];
+    maintainers = with maintainers; [notashelf];
+  };
+})


### PR DESCRIPTION
Simply adds the proton-ge derivation to nix-gaming flake's outputs, I was getting tired of maintaining in my own flake.

[This issue](https://github.com/NixOS/nixpkgs/issues/73323#issuecomment-1079939987) provides instructions on how the user may use the proton-ge derivation on primarily NixOS systems. I assume it would be similar on extending PATH on non-nixos, or linking imperatively. 