### PR TITLE
osu-lazer-bin, osu-stable: handle MIME types

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -39,7 +39,10 @@
 
       osu-mime = pkgs.callPackage ./osu-mime {};
 
-      osu-lazer-bin = pkgs.callPackage ./osu-lazer-bin {inherit pins;};
+      osu-lazer-bin = pkgs.callPackage ./osu-lazer-bin {
+        inherit pins;
+        inherit (config.packages) osu-mime;
+      };
 
       osu-stable = pkgs.callPackage ./osu-stable {
         wine = config.packages.wine-osu;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -37,6 +37,8 @@
       faf-client = pkgs.callPackage ./faf-client {};
       faf-client-unstable = pkgs.callPackage ./faf-client {unstable = true;};
 
+      osu-mime = pkgs.callPackage ./osu-mime {};
+
       osu-lazer-bin = pkgs.callPackage ./osu-lazer-bin {inherit pins;};
 
       osu-stable = pkgs.callPackage ./osu-stable {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -45,6 +45,7 @@
       };
 
       osu-stable = pkgs.callPackage ./osu-stable {
+        inherit (config.packages) osu-mime;
         wine = config.packages.wine-osu;
         wine-discord-ipc-bridge = config.packages.wine-discord-ipc-bridge.override {wine = config.packages.wine-osu;};
       };

--- a/pkgs/osu-lazer-bin/default.nix
+++ b/pkgs/osu-lazer-bin/default.nix
@@ -25,6 +25,7 @@
     # won't hurt users even if they don't have it set up
     then "${gamemode}/bin/gamemoderun"
     else null,
+  osu-mime,
 }: let
   pname = "osu-lazer-bin";
   inherit (pins.osu) version;
@@ -83,16 +84,26 @@
   };
   desktopItem = makeDesktopItem {
     name = pname;
-    exec = "${derivation.outPath}/bin/osu-lazer";
+    exec = "${derivation.outPath}/bin/osu-lazer %U";
     icon = "${derivation.outPath}/osu.png";
     comment = "A free-to-win rhythm game. Rhythm is just a *click* away!";
     desktopName = "osu!";
     categories = ["Game"];
+    mimeTypes = [
+      "application/x-osu-skin-archive"
+      "application/x-osu-replay"
+      "application/x-osu-beatmap-archive"
+      "x-scheme-handler/osu"
+    ];
   };
 in
   symlinkJoin {
     name = "${pname}-${version}";
-    paths = [derivation desktopItem];
+    paths = [
+      derivation
+      desktopItem
+      osu-mime
+    ];
 
     meta = {
       description = "Rhythm is just a *click* away";

--- a/pkgs/osu-mime/default.nix
+++ b/pkgs/osu-mime/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  librsvg,
+  imagemagick,
+}: let
+  osu-web-rev = "96e384d5932c0113d1ad8fa8c6ac1052d1e22268";
+  osu-mime-spec-rev = "a715a74c2188297e61ac629abaed27fa56f0538c";
+in
+  stdenvNoCC.mkDerivation {
+    pname = "osu-mime";
+    version = "unstable-2023-05-31";
+
+    srcs = [
+      (fetchurl {
+        url = "https://raw.githubusercontent.com/ppy/osu-web/${osu-web-rev}/public/images/layout/osu-logo-triangles.svg";
+        sha256 = "4a6vm4H6iOmysy1/fDV6PyfIjfd1/BnB5LZa3Z2noa8=";
+      })
+      (fetchurl {
+        url = "https://raw.githubusercontent.com/ppy/osu-web/${osu-web-rev}/public/images/layout/osu-logo-white.svg";
+        sha256 = "XvYBIGyvTTfMAozMP9gmr3uYEJaMcvMaIzwO7ZILrkY=";
+      })
+      (fetchurl {
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/osu-file-extensions.xml?h=osu-mime&id=${osu-mime-spec-rev}";
+        sha256 = "MgQNW0RpnEYTC0ym6wB8cA6a8GCED1igsjOtHPXNZVo=";
+      })
+    ];
+
+    nativeBuildInputs = [
+      librsvg
+      imagemagick
+    ];
+
+    dontUnpack = true;
+
+    installPhase = ''
+      # Turn $srcs into a bash array
+      read -ra srcs <<< "$srcs"
+
+      mime_dir="$out/share/mime/packages"
+      hicolor_dir="$out/share/icons/hicolor"
+
+      mkdir -p "$mime_dir" "$hicolor_dir"
+
+      # Generate icons
+      # Adapted from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=osu-mime
+      for size in 16 24 32 48 64 96 128 192 256 384 512 1024; do
+          icon_dir="$hicolor_dir/''${size}x''${size}/apps"
+
+          # Generate icon
+          rsvg-convert -w "$size" -h "$size" -f png -o "osu-logo-triangles.png" "''${srcs[0]}"
+          rsvg-convert -w "$size" -h "$size" -f png -o "osu-logo-white.png" "''${srcs[1]}"
+          convert -composite "osu-logo-triangles.png" "osu-logo-white.png" -gravity center 'osu!.png'
+
+          mkdir -p "$icon_dir"
+          mv 'osu!.png' "$icon_dir"
+      done
+
+      cp "''${srcs[2]}" "$mime_dir/osu.xml"
+    '';
+
+    meta = with lib; {
+      description = "MIME types for osu!";
+      license = licenses.agpl3Only; # osu-web uses AGPL v3.0
+      maintainers = with lib.maintainers; [PlayerNameHere];
+      platforms = ["x86_64-linux"];
+    };
+  }

--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -13,6 +13,7 @@
   tricks ? ["gdiplus" "dotnet40" "meiryo"],
   preCommands ? "",
   postCommands ? "",
+  osu-mime,
 }: let
   src = builtins.fetchurl rec {
     url = "https://m1.ppy.sh/r/osu!install.exe";
@@ -67,16 +68,26 @@
 
   desktopItems = makeDesktopItem {
     name = pname;
-    exec = "${script}/bin/${pname}";
+    exec = "${script}/bin/${pname} %U";
     inherit icon;
     comment = "Rhythm is just a *click* away";
     desktopName = "osu!stable";
     categories = ["Game"];
+    mimeTypes = [
+      "application/x-osu-skin-archive"
+      "application/x-osu-replay"
+      "application/x-osu-beatmap-archive"
+      "x-scheme-handler/osu"
+    ];
   };
 in
   symlinkJoin {
     name = pname;
-    paths = [desktopItems script];
+    paths = [
+      desktopItems
+      script
+      osu-mime
+    ];
 
     meta = {
       description = "osu!stable installer and runner";

--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -21,13 +21,6 @@
     sha256 = (builtins.fromJSON (builtins.readFile ./info.json)).hash;
   };
 
-  icon = builtins.fetchurl {
-    # original url = "https://i.ppy.sh/013ed2c11b34720790e74035d9f49078d5e9aa64/68747470733a2f2f6f73752e7070792e73682f77696b692f696d616765732f4272616e645f6964656e746974795f67756964656c696e65732f696d672f75736167652d66756c6c2d636f6c6f75722e706e67";
-    url = "https://user-images.githubusercontent.com/36706276/203341604-085a1896-539e-4401-a458-ad6ee4209df8.png";
-    name = "osu.png";
-    sha256 = "00qka8pn5d5jrlsadwn30aywqn60xqb1nsx2qiqsd73i4xbha0rn";
-  };
-
   # concat winetricks args
   tricksFmt = with builtins;
     if (length tricks) > 0
@@ -69,7 +62,7 @@
   desktopItems = makeDesktopItem {
     name = pname;
     exec = "${script}/bin/${pname} %U";
-    inherit icon;
+    icon = "osu!"; # icon comes from the osu-mime package
     comment = "Rhythm is just a *click* away";
     desktopName = "osu!stable";
     categories = ["Game"];


### PR DESCRIPTION
Adds [MIME type information](https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-0.21.html#idm46148007863824) and icons for file types used by osu! and makes the desktop files of `osu-lazer-bin` and `osu-stable` handle them. This allows, for example, double clicking on an `.osz` file in a file manager to automatically launch `osu-lazer-bin` or `osu-stable` and have them import the beatmap archive. The desktop files will now also handle `osu://` URLs (which can be tested using `xdg-open <url>` or a similar tool; the URL schema can be found at the bottom of [this page](https://github.com/ppy/osu-api/wiki#reference)).

The MIME type information and icons are contained in a new `osu-mime` package, which is added to `osu-lazer-bin` and `osu-stable`'s `symlinkJoin`. I'm not sure if this is the best approach though. Thoughts?

Unfortunately, for `osu-stable`, I get an error pop-up window stating `Error moving file <.osz file>` when opening an `.osz` file, but this also happens when calling `osu-stable <.osz file>` directly in a terminal, so I think it's unrelated to this PR. Probably a wine quirk? `osu://` URL handling works though.