### PR TITLE
README.md: remove deprecated url syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ adding `nix-gaming` as an input:
 ```nix
 # flake.nix
 {
-  inputs.nix-gaming.url = github:fufexan/nix-gaming;
+  inputs.nix-gaming.url = "github:fufexan/nix-gaming";
 }
 ```
 


### PR DESCRIPTION
Per [RFC 45](https://github.com/NixOS/rfcs/blob/master/rfcs/0045-deprecate-url-syntax.md), URL literals are deprecated. Strings should be used instead. No URL literals are used in this flake, but the readme still recommends deprecated syntax.