### PR TITLE
proton-ge: 8.4 -> 8.6

### DIFF
--- a/pkgs/proton-ge/README.md
+++ b/pkgs/proton-ge/README.md
@@ -1,4 +1,17 @@
 # Proton-GE
 
 To use `proton-ge`, you must add it to your steam compatibility tools path.
+
+A simple implementation would be to use the overlay:
+
+```nix
+nixpkgs.overlays = [
+    (_: prev: {
+        steam = prev.steam.override {
+            extraProfile = "export STEAM_EXTRA_COMPAT_TOOLS_PATHS='${inputs.nix-gaming.packages.${pkgs.system}.proton-ge}'";
+        };
+    })
+];
+```
+
 More info can be found [here](https://github.com/NixOS/nixpkgs/issues/73323#issuecomment-1079939987).

--- a/pkgs/proton-ge/default.nix
+++ b/pkgs/proton-ge/default.nix
@@ -5,11 +5,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "proton-ge-custom";
-  version = "GE-Proton8-4";
+  version = "GE-Proton8-6";
 
   src = fetchurl {
     url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
-    hash = "sha256-OPwmVxBGaWo51pDJcqvxvZ8qxMH8X0DwZTpwiKbdx/I=";
+    hash = "sha256-0ePO6ZzsZpAb9iM++k4fYDwKzJpuZNgfPKwZePAUc0Y=";
   };
 
   buildCommand = ''


### PR DESCRIPTION
Bumps proton-ge-custom to current latest version, adds basic usage instructions to the proton-ge's README.