### PR TITLE
Fix: npins wrongly selecting game-specific proton versions

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -105,10 +105,10 @@
         "owner": "GloriousEggroll",
         "repo": "proton-wine"
       },
-      "branch": "Proton8-12-LoL",
-      "revision": "99c1c3153ef552b215be92c6857fcd2fd1625c54",
-      "url": "https://github.com/GloriousEggroll/proton-wine/archive/99c1c3153ef552b215be92c6857fcd2fd1625c54.tar.gz",
-      "hash": "0pbbmys6ggyn3qmkivnlhya51brgvk6agih9yxlc2d4wzzvb9als"
+      "branch": "Proton8-12",
+      "revision": "60227516f6eecb358cfb5533367c3ee0218c4954",
+      "url": "https://github.com/GloriousEggroll/proton-wine/archive/60227516f6eecb358cfb5533367c3ee0218c4954.tar.gz",
+      "hash": "0jimd05day1ds3wz0gy9g5n80adcwxay40zmh90f690wh48p41ga"
     },
     "vkd3d-proton": {
       "type": "GitRelease",

--- a/pkgs/wine/update-wine-ge.sh
+++ b/pkgs/wine/update-wine-ge.sh
@@ -12,7 +12,7 @@ latest_minor=0
 
 # Find the latest version
 for branch in $branches; do
-  if [[ $branch =~ ^Proton([0-9]+)-([0-9]+) ]]; then
+  if [[ $branch =~ ^Proton([0-9]+)-([0-9]+)$ ]]; then
     major=${BASH_REMATCH[1]}
     minor=${BASH_REMATCH[2]}
     if (( major > latest_major )) || (( major == latest_major && minor > latest_minor )); then


### PR DESCRIPTION
* Update `pkgs/wine/update-wine-ge.sh` to exclude game specific versions

* Update `npins/sources.json` to correct to the most up to date proton version

Fixes #94.