### PR TITLE
wine-discord-ipc-bridge: add steam bridge

### DIFF
--- a/pkgs/wine-discord-ipc-bridge/README.md
+++ b/pkgs/wine-discord-ipc-bridge/README.md
@@ -2,3 +2,4 @@
 
 `wine-discord-ipc-bridge` provides bridging between games under Wine and
 Discord running on Linux.
+`winediscordipcbridge-steam.sh` provides briding between games under Steam and Discord running on Linux. 

--- a/pkgs/wine-discord-ipc-bridge/default.nix
+++ b/pkgs/wine-discord-ipc-bridge/default.nix
@@ -16,11 +16,11 @@ in
 
     nativeBuildInputs = [pkgsCross.mingw32.stdenv.cc wine];
 
-    installPhase = "
-    mkdir -p $out/bin; 
-    cp winediscordipcbridge.exe $out/bin; 
-    cp winediscordipcbridge-steam.sh $out/bin
-    ";
+    installPhase = ''
+      mkdir -p $out/bin
+      cp winediscordipcbridge.exe $out/bin
+      cp winediscordipcbridge-steam.sh $out/bin
+    '';
 
     meta = {
       description = "Enable games running under wine to use Discord Rich Presence";

--- a/pkgs/wine-discord-ipc-bridge/default.nix
+++ b/pkgs/wine-discord-ipc-bridge/default.nix
@@ -16,7 +16,8 @@ in
 
     nativeBuildInputs = [pkgsCross.mingw32.stdenv.cc wine];
 
-    installPhase = "mkdir -p $out/bin; cp winediscordipcbridge.exe $out/bin; cp winediscordipcbridge-steam.sh $out/bin";
+    installPhase = "mkdir -p $out/bin; cp winediscordipcbridge.exe $out/bin; 
+    cp winediscordipcbridge-steam.sh $out/bin";
 
     meta = {
       description = "Enable games running under wine to use Discord Rich Presence";

--- a/pkgs/wine-discord-ipc-bridge/default.nix
+++ b/pkgs/wine-discord-ipc-bridge/default.nix
@@ -16,7 +16,7 @@ in
 
     nativeBuildInputs = [pkgsCross.mingw32.stdenv.cc wine];
 
-    installPhase = "mkdir -p $out/bin; cp winediscordipcbridge.exe $out/bin";
+    installPhase = "mkdir -p $out/bin; cp winediscordipcbridge.exe $out/bin; cp winediscordipcbridge-steam.sh $out/bin";
 
     meta = {
       description = "Enable games running under wine to use Discord Rich Presence";

--- a/pkgs/wine-discord-ipc-bridge/default.nix
+++ b/pkgs/wine-discord-ipc-bridge/default.nix
@@ -16,8 +16,11 @@ in
 
     nativeBuildInputs = [pkgsCross.mingw32.stdenv.cc wine];
 
-    installPhase = "mkdir -p $out/bin; cp winediscordipcbridge.exe $out/bin; 
-    cp winediscordipcbridge-steam.sh $out/bin";
+    installPhase = "
+    mkdir -p $out/bin; 
+    cp winediscordipcbridge.exe $out/bin; 
+    cp winediscordipcbridge-steam.sh $out/bin
+    ";
 
     meta = {
       description = "Enable games running under wine to use Discord Rich Presence";


### PR DESCRIPTION
to use, check ``whereis winediscordipcbridge-steam.sh`` and add ``/bin/winediscordipcbridge-steam.sh %command%`` in the launch options there might be a better way, but im not sure.

fixes #96 