### PR TITLE
Added Darkest Dungeon (GoG) derivation

### DIFF
--- a/pkgs/darkest-dungeon/default.nix
+++ b/pkgs/darkest-dungeon/default.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  requireFile,
+  makeDesktopItem,
+  copyDesktopItems,
+  autoPatchelfHook,
+  makeBinaryWrapper,
+  stdenvNoCC,
+  zip,
+  unzip,
+  SDL2,
+  libcxx,
+  libGL,
+  fmodex,
+  libmx,
+  libX11,
+  libXext,
+  libxcb,
+  libXau,
+  libXdmcp,
+}: let
+  commonDeps = [
+    SDL2
+    libcxx
+    libGL
+    fmodex
+    libmx
+    fmodex
+    libX11
+    libXext
+    libxcb
+    libXau
+    libXdmcp
+  ];
+in
+  stdenvNoCC.mkDerivation rec {
+    pname = "darkest-dungeon";
+    version = "24839_28859";
+
+    # The official installer must be provided by the end user.
+    src = requireFile {
+      name = "darkest_dungeon_${version}.sh";
+      url = "https://www.gog.com/game/darkest_dungeon";
+      sha256 = "2b235b43d8d6ab4b2a4b80b627ce2a9c31c1b4bee16fc6f9dda68c29cb5da99c";
+    };
+
+    nativeBuildInputs =
+      [
+        autoPatchelfHook
+        makeBinaryWrapper
+        unzip
+        zip
+        copyDesktopItems
+      ]
+      ++ commonDeps;
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = pname;
+        desktopName = "Darkest Dungeon";
+        genericName = "Loosing your will to live; the game.";
+        exec = "darkest";
+        #icon = "CCicon";  # The proper icon needs to be set instead.
+        comment = "Darkest Dungeon GoG version.";
+        categories = ["Game"];
+      })
+    ];
+
+    # FIXME: I know this is curserd, but for some reason, it is required.
+    unpackPhase = ''
+      # First, creates a new fixed zip archive from the original installer.
+      zip -F $src --out fixed-src.zip
+
+      # Then extracts that one instead.
+      unzip  fixed-src.zip
+    '';
+
+    installPhase = ''
+      mkdir -p $out/share/${pname}
+
+      # Only copies this folder since the rest is useless.
+      mv data/noarch/game/* $out/share/${pname}
+
+      # Create .desktop entries.
+      copyDesktopItems
+
+      # Creates the wrapper for the game.
+      makeBinaryWrapper $out/share/${pname}/darkest.bin.x86_64 $out/bin/darkest \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath commonDeps}
+    '';
+
+    # Metadata
+    meta = with lib; {
+      description = "The game that would drive you into utter maddness.";
+      longDescription = "Darkest Dungeon GoG version. Without any DLCs.";
+      homepage = "https://www.darkestdungeon.com/";
+      downloadPage = "https://www.gog.com/game/darkest_dungeon";
+      license = licenses.unfree;
+      mainProgram = "darkest";
+      maintainers = with maintainers; [notevil];
+      platforms = platforms.linux;
+    };
+  }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -30,6 +30,8 @@
           // extra))
         .${wine};
     in {
+      darkest-dungeon = pkgs.callPackage ./darkest-dungeon {};
+
       dxvk = pkgs.callPackage ./dxvk {inherit pins;};
       dxvk-w32 = pkgs.pkgsCross.mingw32.callPackage ./dxvk {inherit pins;};
       dxvk-w64 = pkgs.pkgsCross.mingwW64.callPackage ./dxvk {inherit pins;};


### PR DESCRIPTION
Adds a **Darkest Dungeon** derivation. _([Link to the game website](https://www.darkestdungeon.com/darkest-dungeon/))._

This is related to the issue #110. While this is just a single game and not a builder I think it still has value because:

1. Immediately provides another game to possible end users.
2. It serves as an starting point and I would very much appreciate constructive criticism. I'm a bit noob with nix. 😅

#### WIP
- I still need to iron out some things like gamemode support, a proper icon and maybe clean up some bits here and there.
- Documentation is also missing since I feel that a disclaimer stating that this is not piracy and the end user need to provide the original installer. 