### PR TITLE
proton-ge: 8.31 -> 8.32

### DIFF
--- a/pkgs/proton-ge/default.nix
+++ b/pkgs/proton-ge/default.nix
@@ -1,16 +1,16 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   fetchurl,
   nix-update-script,
 }:
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "proton-ge-custom";
-  version = "GE-Proton8-31";
+  version = "GE-Proton8-32";
 
   src = fetchurl {
     url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
-    hash = "sha256-ogxZmso7F0q+VB7/NYTvIiqPt5OCxkoAXhtvNr6KVC4=";
+    hash = "sha256-U+5CvBVWCFQRMtb7+KcaHx9Coj7cXg5V0EJd+e51PaA=";
   };
 
   buildCommand = ''


### PR DESCRIPTION
- **proton-ge: 8.31 -> 8.32**
- Uses stdenvNoCC instead of stdenv, since we don't need a compiler for unarchiving a tar.
