### PR TITLE
fix(osu-lazer-bin): update osu!lazer: 2024.210.0 -> 2024.219.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,18 @@ jobs:
           - faf-client
           - faf-client-unstable
           - proton-ge
+          - northstar-proton
           - wine-ge
           - wine-osu
           - wine-tkg
+          - wine-discord-ipc-bridge
+          - winestreamproxy
+          - osu-stable
+          - osu-lazer-bin
+          - rocket-league
+          - star-citizen
+          - technic-launcher
+          - viper
 
     uses: ./.github/workflows/nix.yml
     with:

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708151420,
-        "narHash": "sha256-MGT/4aGCWQPQiu6COqJdCj9kSpLPiShgbwpbC38YXC8=",
+        "lastModified": 1708341091,
+        "narHash": "sha256-3R7doGV1AoB5VKFifEd5elj8t4cld6VpJRpn9NaYr1Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e2f00c83911461438301db0dba5281197fe4b3a",
+        "rev": "86ef6bd96b6279e1a4a53236d341f5df1ede3803",
         "type": "github"
       },
       "original": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -93,9 +93,9 @@
       },
       "pre_releases": false,
       "version_upper_bound": null,
-      "version": "2024.210.0",
-      "revision": "4a516cbccd2bc3aaa7b5b4d6b4ebf009c43485bc",
-      "url": "https://api.github.com/repos/ppy/osu/tarball/2024.210.0",
+      "version": "2024.219.0",
+      "revision": "c87bc8b597127e5c6119d04dc5a84d567c49be53",
+      "url": "https://api.github.com/repos/ppy/osu/tarball/2024.219.0",
       "hash": "0zgxj2dyjlc4q0nyyhhn5mpxjdjnnp003bpczpgay54c02zjcvz4"
     },
     "proton-wine": {

--- a/pkgs/osu-lazer-bin/info.json
+++ b/pkgs/osu-lazer-bin/info.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-aNG6s942iTKyvM1XolMqmMs8XxoRYC/ZddCCJl0OtTE=",
+  "hash": "sha256-EqQJolzai0LrVpYE6yjbEUURNiUgi9Lw+otdmKIyoXo=",
   "storePath": "/nix/store/svxz8clgl17k8wl40f0bblsl8nj3pbw1-osu.AppImage",
-  "version": "2024.131.0"
+  "version": "2024.219.0"
 }


### PR DESCRIPTION
Hi. After last update(18.02.2024), osu-lazer-bin had a problem with downloading osu.AppImage.  The problem was, the osu.AppImage is missing this release.

![image](https://github.com/fufexan/nix-gaming/assets/32981591/4b5020a2-9b62-4388-8109-091a0c252d25)

 I checked manually on [official osu! repo](https://github.com/ppy/osu/releases/tag/2024.210.0) and it includes only tar and zip archive with source code. Then, I changed version general for osu! in `sources.json`(I deduced it, based on previous package updates). Also, I added osu-lazer-bin and a few games, because pipeline for them weren't run and haven't check if packaged built correct.

Side notes for reviewers:
- During my work, I discoverded something werid in pipeline for osu-lazer-bin. After, I added the package to pipeline, it built correct without any errors. This was weird cause I try build manually on my local machine and locally nix-gaming repsository and I got the same error: 
![image](https://github.com/fufexan/nix-gaming/assets/32981591/98def9c4-8fe2-4b8c-a945-6415b35a70f9)
- I wanna added more games/packages that didn't mention in README.md e.g. dxvk or dxvk-w32, but those packages didn't build on local machine or pipeline. I don't know, those packages is depreceted or don't have mainteners, that update them. In this case, I didn't add them to build.yml pipeline
- I didn't update `hash` in `sources.json` from 2 reasons: 1) When I try generate hash from osu! files for previous version, I didn't get the same hash, that it was in the file. If someone know, Which file should I generate hash for this file, please tell me. I don't know, what did I wrong :( 2)  In other hand, I don't know, what purpose has this hash? After searching code, I found only 1 place, where it uses: npins.nix. I don't find any purpose for the hash, so may someone could explain me, what exectly the hash do and where it use?