### PR TITLE
modules: add platformOptimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ in {
 
 ## Modules
 
-Here are some NixOS modules for settings gaming related options.
+Here are some NixOS modules for setting gaming related options.
 
 ### Installation
 
@@ -206,11 +206,11 @@ You can calculate the theoretical latency by dividing `quantum` by `rate`
 ### SteamOS sysctl settings
 
 [SteamOS](https://store.steampowered.com/steamos) on the steam deck has set some
-specific sysctl settings. These include settings to enable some games to run at all,
-or perform better.
+specific sysctl settings, so that some games can be run at all, or perform better under 
+certain circumstances.
 
-This module extends the Steam module from Nixpkgs but can be set as a standalone
-by just enabling them.
+This module extends the Steam module from Nixpkgs but can be enabled as a 
+standalone option.
 
 #### Usage
 

--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ See an overview of the flake outputs by running
 
 ## 🗃️ What's in here?
 
-Package                                                     | Description
------------------------------------------------------------ | -----------
-[`faf-client`](./pkgs/faf-client)                           | Forged Alliance Forever client (multiple packages)
-[`osu-lazer-bin`](./pkgs/osu-lazer-bin)                     | osu! lazer, extracted from the official AppImage
-[`osu-stable`](./pkgs/osu-stable)                           | osu! stable version
-`rocket-league`                                             | Rocket League from Epic Games
-[`star-citizen`](./pkgs/star-citizen)                       | Star Citizen
-[`technic-launcher`](./pkgs/technic-launcher)               | Technic Launcher
-[`wine-discord-ipc-bridge`](./pkgs/wine-discord-ipc-bridge) | Wine-Discord RPC Bridge
-[`wine`](./pkgs/wine)                                       | Multiple Wine packages
-[`winestreamproxy`](./pkgs/winestreamproxy)                 | Wine-Discord RPC (broken)
-[`proton-ge`](./pkgs/proton-ge)                             | Custom build of Proton with the most recent bleeding-edge Proton Experimental WINE
-[`northstar-proton`](./pkgs/titanfall/northstar-proton.nix) | Proton build based on TKG's proton-tkg build system to run the Northstar client on Linux and SteamDeck
-[`viper`](./pkgs/titanfall/viper.nix)                       | Launcher+Updater for Titanfall2 Northstar Client
+| Package                                                     | Description                                                                                            |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [`faf-client`](./pkgs/faf-client)                           | Forged Alliance Forever client (multiple packages)                                                     |
+| [`osu-lazer-bin`](./pkgs/osu-lazer-bin)                     | osu! lazer, extracted from the official AppImage                                                       |
+| [`osu-stable`](./pkgs/osu-stable)                           | osu! stable version                                                                                    |
+| `rocket-league`                                             | Rocket League from Epic Games                                                                          |
+| [`star-citizen`](./pkgs/star-citizen)                       | Star Citizen                                                                                           |
+| [`technic-launcher`](./pkgs/technic-launcher)               | Technic Launcher                                                                                       |
+| [`wine-discord-ipc-bridge`](./pkgs/wine-discord-ipc-bridge) | Wine-Discord RPC Bridge                                                                                |
+| [`wine`](./pkgs/wine)                                       | Multiple Wine packages                                                                                 |
+| [`winestreamproxy`](./pkgs/winestreamproxy)                 | Wine-Discord RPC (broken)                                                                              |
+| [`proton-ge`](./pkgs/proton-ge)                             | Custom build of Proton with the most recent bleeding-edge Proton Experimental WINE                     |
+| [`northstar-proton`](./pkgs/titanfall/northstar-proton.nix) | Proton build based on TKG's proton-tkg build system to run the Northstar client on Linux and SteamDeck |
+| [`viper`](./pkgs/titanfall/viper.nix)                       | Launcher+Updater for Titanfall2 Northstar Client                                                       |
 
 - `legendaryBuilder` is a function that installs games with `legendary-gl`. You
   are expected to log in before using it, with `legendary auth`.
@@ -206,10 +206,10 @@ You can calculate the theoretical latency by dividing `quantum` by `rate`
 ### SteamOS sysctl settings
 
 [SteamOS](https://store.steampowered.com/steamos) on the steam deck has set some
-specific sysctl settings, so that some games can be run at all, or perform better under 
+specific sysctl settings, so that some games can be run at all, or perform better under
 certain circumstances.
 
-This module extends the Steam module from Nixpkgs but can be enabled as a 
+This module extends the Steam module from Nixpkgs but can be enabled as a
 standalone option.
 
 #### Usage
@@ -218,7 +218,7 @@ After importing the module in your configuration like described above, enable it
 
 ```nix
 {
-  programs.steam.steamosSysctls.enable = true;
+  programs.steam.platformOptimizations.enable = true;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ If you get no sound, you may want to increase `quantum`.
 You can calculate the theoretical latency by dividing `quantum` by `rate`
 (`48/48000` is exactly 1ms).
 
-### SteamOS sysctl settings
+### Platform optimizations
 
 [SteamOS](https://store.steampowered.com/steamos) on the steam deck has set some
 specific sysctl settings, so that some games can be run at all, or perform better under

--- a/README.md
+++ b/README.md
@@ -126,16 +126,13 @@ in {
 }
 ```
 
-## PipeWire low latency
+## Modules
 
-[PipeWire](https://nixos.wiki/wiki/PipeWire) is a new audio backend that
-replaces ALSA, PulseAudio and JACK. It is as low latency as JACK and as easy to
-use as Pulse.
+Here are some NixOS modules for settings gaming related options.
 
-This module extends the PipeWire module from Nixpkgs and makes it easy to enable
-the low latency settings in a few lines.
+### Installation
 
-### Flakes
+#### Flakes
 
 Assuming you've followed the [Install/Flakes](#️-flakes) instructions, all you
 need to do is add the module to your configuration like this:
@@ -143,14 +140,14 @@ need to do is add the module to your configuration like this:
 ```nix
 {inputs, ...}: {
   imports = [
-    inputs.nix-gaming.nixosModules.pipewireLowLatency
+    inputs.nix-gaming.nixosModules.<module name>
   ];
 }
 ```
 
-Now you can skip to [Usage](#usage).
+Now you can skip to the Usage section of a specific module.
 
-### Stable
+#### Stable
 
 Assuming you've followed the [Install/Nix Stable](#nix-stable) instructions, all
 you need to do is add the module to your configuration like this:
@@ -160,14 +157,24 @@ you need to do is add the module to your configuration like this:
   nix-gaming = /* ... */;
 in {
   imports = [
-    nix-gaming.nixosModules.pipewireLowLatency
+    nix-gaming.nixosModules.<module name>
   ];
 }
 ```
 
-### Usage
+### PipeWire low latency
 
-Import the module in your configuration and enable it along with PipeWire:
+[PipeWire](https://nixos.wiki/wiki/PipeWire) is a new audio backend that
+replaces ALSA, PulseAudio and JACK. It is as low latency as JACK and as easy to
+use as Pulse.
+
+This module extends the PipeWire module from Nixpkgs and makes it easy to enable
+the low latency settings in a few lines.
+
+#### Usage
+
+After importing the module in your configuration like described above, enable it
+along with PipeWire:
 
 ```nix
 {
@@ -196,8 +203,26 @@ If you get no sound, you may want to increase `quantum`.
 You can calculate the theoretical latency by dividing `quantum` by `rate`
 (`48/48000` is exactly 1ms).
 
+### SteamOS sysctl settings
 
-### ⚙ Game overrides
+[SteamOS](https://store.steampowered.com/steamos) on the steam deck has set some
+specific sysctl settings. These include settings to enable some games to run at all,
+or perform better.
+
+This module extends the Steam module from Nixpkgs but can be set as a standalone
+by just enabling them.
+
+#### Usage
+
+After importing the module in your configuration like described above, enable it like this:
+
+```nix
+{
+  programs.steam.steamosSysctls.enable = true;
+}
+```
+
+## ⚙ Game overrides
 
 Wine-based game derivations were written with versatility in mind.
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -23,6 +23,8 @@
       '';
     };
 
+    steamosSysctls = import ./steamosSysctls;
+
     default = throw ''
       The usage of default module is deprecated as multiple modules are provided by nix-gaming. Please use
       the exact name of the module you would like to use. Available modules are:

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -23,7 +23,7 @@
       '';
     };
 
-    steamosSysctls = import ./steamosSysctls;
+    platformOptimizations = import ./platformOptimizations.nix;
 
     default = throw ''
       The usage of default module is deprecated as multiple modules are provided by nix-gaming. Please use

--- a/modules/platformOptimizations.nix
+++ b/modules/platformOptimizations.nix
@@ -4,12 +4,12 @@
   ...
 }: {
   options = {
-    programs.steam.steamosSysctls.enable = lib.mkEnableOption ''
+    programs.steam.platformOptimizations.enable = lib.mkEnableOption ''
       set the same sysctl settings as are set on SteamOS
     '';
   };
 
-  config = lib.mkIf config.programs.steam.steamosSysctls.enable {
+  config = lib.mkIf config.programs.steam.platformOptimizations.enable {
     # last cheched with https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/steamos-customizations-jupiter-20240219.1-2-any.pkg.tar.zst
     boot.kernel.sysctl = {
       # 20-shed.conf

--- a/modules/steamosSysctls.nix
+++ b/modules/steamosSysctls.nix
@@ -4,12 +4,12 @@
   ...
 }: {
   options = {
-    programs.steam.setSysctls = lib.mkEnableOption ''
+    programs.steam.steamosSysctls.enable = lib.mkEnableOption ''
       set the same sysctl settings as are set on SteamOS.
     '';
   };
 
-  config = lib.mkIf config.programs.steam.setSysctls {
+  config = lib.mkIf config.programs.steam.steamosSysctls.enable {
     # taken from https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/steamos-customizations-jupiter-20230911.1-1-any.pkg.tar.zst
     boot.kernel.sysctl = {
       # 20-shed.conf

--- a/modules/steamosSysctls.nix
+++ b/modules/steamosSysctls.nix
@@ -5,7 +5,7 @@
 }: {
   options = {
     programs.steam.steamosSysctls.enable = lib.mkEnableOption ''
-      set the same sysctl settings as are set on SteamOS.
+      set the same sysctl settings as are set on SteamOS
     '';
   };
 

--- a/modules/steamosSysctls.nix
+++ b/modules/steamosSysctls.nix
@@ -10,7 +10,7 @@
   };
 
   config = lib.mkIf config.programs.steam.steamosSysctls.enable {
-    # taken from https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/steamos-customizations-jupiter-20230911.1-1-any.pkg.tar.zst
+    # last cheched with https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/steamos-customizations-jupiter-20240219.1-2-any.pkg.tar.zst
     boot.kernel.sysctl = {
       # 20-shed.conf
       "kernel.sched_cfs_bandwidth_slice_us" = 3000;

--- a/modules/steamosSysctls.nix
+++ b/modules/steamosSysctls.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  ...
+}: {
+  options = {
+    programs.steam.setSysctls = lib.mkEnableOption ''
+      set the same sysctl settings as are set on SteamOS.
+    '';
+  };
+
+  config = lib.mkIf config.programs.steam.setSysctls {
+    # taken from https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/steamos-customizations-jupiter-20230911.1-1-any.pkg.tar.zst
+    boot.kernel.sysctl = {
+      # 20-shed.conf
+      "kernel.sched_cfs_bandwidth_slice_us" = 3000;
+      # 20-net-timeout.conf
+      # This is required due to some games being unable to reuse their TCP ports
+      # if they're killed and restarted quickly - the default timeout is too large.
+      "net.ipv4.tcp_fin_timeout" = 5;
+      # 30-vm.conf
+      # USE MAX_INT - MAPCOUNT_ELF_CORE_MARGIN.
+      # see comment in include/linux/mm.h in the kernel tree.
+      "vm.max_map_count" = 2147483642;
+    };
+  };
+}


### PR DESCRIPTION
These settings are taken from the [`steamos-customizations-jupiter`](https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/steamos-customizations-jupiter-20230911.1-1-any.pkg.tar.zst) package on SteamOS.