### PR TITLE
osu-stable: fix connection issues in installer and client

### DIFF
--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -10,7 +10,7 @@
   wineFlags ? "",
   pname ? "osu-stable",
   location ? "$HOME/.osu",
-  tricks ? ["gdiplus" "dotnet40" "meiryo"],
+  tricks ? ["gdiplus" "dotnet45" "meiryo"],
   preCommands ? "",
   postCommands ? "",
   osu-mime,


### PR DESCRIPTION
Details on the fix can be found on [ThePooN's discord server](https://discord.com/channels/209933203782369281/1225791538366386326/1225791539717079124).
This does not fix prefixes created before the patch, to do that you have to run `winetricks -q dotnet45` within the existing osu prefix.

Fixes: #174 