### PR TITLE
add bakkesmod for rocket league

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -83,7 +83,6 @@
       };
 
       rocket-league = pkgs.callPackage ./rocket-league {wine = config.packages.wine-tkg;};
-      bakkesmod = pkgs.callPackage ./rocket-league/bakkesmod.nix {wine = config.packages.wine-tkg;};
 
       star-citizen = pkgs.callPackage ./star-citizen {wine = config.packages.wine-ge;};
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -83,6 +83,7 @@
       };
 
       rocket-league = pkgs.callPackage ./rocket-league {wine = config.packages.wine-tkg;};
+      bakkesmod = pkgs.callPackage ./rocket-league/bakkesmod.nix {wine = config.packages.wine-tkg;};
 
       star-citizen = pkgs.callPackage ./star-citizen {wine = config.packages.wine-ge;};
 

--- a/pkgs/rocket-league/bakkesmod.nix
+++ b/pkgs/rocket-league/bakkesmod.nix
@@ -17,18 +17,21 @@
 
   bakkesmodExePath = "${location}/drive_c/Program Files/BakkesMod/BakkesMod.exe";
 
-  installBakkesmod = writeShellScriptBin "install-bakkesmod" ''
-    # Fetch bakkesmod installer and unzip it
-    curl -L https://github.com/bakkesmodorg/BakkesModInjectorCpp/releases/latest/download/BakkesModSetup.zip --output ~/Downloads/BakkesModSetup.zip
+  bakkesmodInstaller = writeShellScriptBin "install-bakkesmod" ''
+    # Create a temp dir for the installer file
+    export TEMP_DIR=$(mktemp -d)
 
-    ${unzip}/bin/unzip ~/Downloads/BakkesModSetup.zip -d ~/Downloads/
+    # Fetch bakkesmod installer and unzip it
+    curl -L https://github.com/bakkesmodorg/BakkesModInjectorCpp/releases/latest/download/BakkesModSetup.zip --output $TEMP_DIR/BakkesModSetup.zip
+
+    ${unzip}/bin/unzip $TEMP_DIR/BakkesModSetup.zip -d $TEMP_DIR
 
     # Run the bakkesmod installer
-    WINEPREFIX="${location}" ${wine}/bin/wine ~/Downloads/BakkesModSetup.exe
+    WINEPREFIX="${location}" ${wine}/bin/wine $TEMP_DIR/BakkesModSetup.exe
 
     # Clean up
-    rm ~/Downloads/BakkesModSetup.zip
-    rm ~/Downloads/BakkesModSetup.exe
+    rm $TEMP_DIR/BakkesModSetup.zip
+    rm $TEMP_DIR/BakkesModSetup.exe
     '';
 
   bakkesmodScript = writeShellScriptBin "bakkesmod" ''
@@ -37,7 +40,9 @@
 
     if [ ! -f "${bakkesmodExePath}" ]; then
         echo "${bakkesmodExePath} does not exist, installing bakkesmod..."
-        ${installBakkesmod}/bin/install-bakkesmod
+        ${bakkesmodInstaller}/bin/install-bakkesmod
+        echo "done installing, run 'bakkesmod' again to start bakkesmod"
+        exit 0
     fi
 
     WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine c:/Program\ Files/BakkesMod/BakkesMod.exe

--- a/pkgs/rocket-league/bakkesmod.nix
+++ b/pkgs/rocket-league/bakkesmod.nix
@@ -27,7 +27,7 @@
     ${unzip}/bin/unzip $TEMP_DIR/BakkesModSetup.zip -d $TEMP_DIR
 
     # Run the bakkesmod installer
-    WINEPREFIX="${location}" ${wine}/bin/wine $TEMP_DIR/BakkesModSetup.exe
+    WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine $TEMP_DIR/BakkesModSetup.exe
 
     # Clean up
     rm $TEMP_DIR/BakkesModSetup.zip
@@ -41,10 +41,10 @@
     if [ ! -f "${bakkesmodExePath}" ]; then
         echo "${bakkesmodExePath} does not exist, installing bakkesmod..."
         ${bakkesmodInstaller}/bin/install-bakkesmod
-        echo "done installing, run 'bakkesmod' again to start bakkesmod"
-        exit 0
+        echo "finished installing bakkesmod"
     fi
 
+    echo "Starting bakkesmod..."
     WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine c:/Program\ Files/BakkesMod/BakkesMod.exe
 
     '';

--- a/pkgs/rocket-league/bakkesmod.nix
+++ b/pkgs/rocket-league/bakkesmod.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  makeDesktopItem,
+  symlinkJoin,
+  writeShellScriptBin,
+  unzip,
+  wine,
+  pname ? "rocket-league",
+  location ? "$HOME/Games/${pname}",
+}: let
+
+  bakkesmodIcon = builtins.fetchurl {
+    url = "https://bp-prod.nyc3.digitaloceanspaces.com/site-assets/static/bm-transparent.png";
+    name = "bakkesmod.png";
+    sha256 = "18n6hcab25n9i4v2vmq6p8v7ii17p4x9i9jx3b300lfqm56239y7";
+  };
+
+  bakkesmodExePath = "${location}/drive_c/Program Files/BakkesMod/BakkesMod.exe";
+
+  installBakkesmod = writeShellScriptBin "install-bakkesmod" ''
+    # Fetch bakkesmod installer and unzip it
+    curl -L https://github.com/bakkesmodorg/BakkesModInjectorCpp/releases/latest/download/BakkesModSetup.zip --output ~/Downloads/BakkesModSetup.zip
+
+    ${unzip}/bin/unzip ~/Downloads/BakkesModSetup.zip -d ~/Downloads/
+
+    # Run the bakkesmod installer
+    WINEPREFIX="${location}" ${wine}/bin/wine ~/Downloads/BakkesModSetup.exe
+
+    # Clean up
+    rm ~/Downloads/BakkesModSetup.zip
+    rm ~/Downloads/BakkesModSetup.exe
+    '';
+
+  bakkesmodScript = writeShellScriptBin "bakkesmod" ''
+
+    echo "bakkesmod exe path: ${bakkesmodExePath}"
+
+    if [ ! -f "${bakkesmodExePath}" ]; then
+        echo "${bakkesmodExePath} does not exist, installing bakkesmod..."
+        ${installBakkesmod}/bin/install-bakkesmod
+    fi
+
+    WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine c:/Program\ Files/BakkesMod/BakkesMod.exe
+
+    '';
+
+  bakkesmodDesktopItem = makeDesktopItem {
+    name = "bakkesmod";
+    exec = "${bakkesmodScript}/bin/bakkesmod";
+    icon = bakkesmodIcon;
+    desktopName = "Bakkesmod (Rocket League mod)";
+    categories = ["Game"];
+  };
+
+in 
+  symlinkJoin {
+    name = "bakkesmod";
+    paths = [bakkesmodDesktopItem bakkesmodScript];
+
+    meta = {
+      description = "Rocket League mod";
+      homepage = "https://www.bakkesmod.com";
+      platforms = ["x86_64-linux"];
+    };
+  }
+

--- a/pkgs/rocket-league/bakkesmod.nix
+++ b/pkgs/rocket-league/bakkesmod.nix
@@ -3,13 +3,13 @@
   makeDesktopItem,
   symlinkJoin,
   writeShellScriptBin,
+  fetchurl,
   unzip,
   wine,
   pname ? "rocket-league",
   location ? "$HOME/Games/${pname}",
 }: let
-
-  bakkesmodIcon = builtins.fetchurl {
+  bakkesmodIcon = fetchurl {
     url = "https://bp-prod.nyc3.digitaloceanspaces.com/site-assets/static/bm-transparent.png";
     name = "bakkesmod.png";
     sha256 = "18n6hcab25n9i4v2vmq6p8v7ii17p4x9i9jx3b300lfqm56239y7";
@@ -32,7 +32,7 @@
     # Clean up
     rm $TEMP_DIR/BakkesModSetup.zip
     rm $TEMP_DIR/BakkesModSetup.exe
-    '';
+  '';
 
   bakkesmodScript = writeShellScriptBin "bakkesmod" ''
 
@@ -47,7 +47,7 @@
     echo "Starting bakkesmod..."
     WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine c:/Program\ Files/BakkesMod/BakkesMod.exe
 
-    '';
+  '';
 
   bakkesmodDesktopItem = makeDesktopItem {
     name = "bakkesmod";
@@ -56,8 +56,7 @@
     desktopName = "Bakkesmod (Rocket League mod)";
     categories = ["Game"];
   };
-
-in 
+in
   symlinkJoin {
     name = "bakkesmod";
     paths = [bakkesmodDesktopItem bakkesmodScript];
@@ -68,4 +67,3 @@ in
       platforms = ["x86_64-linux"];
     };
   }
-

--- a/pkgs/rocket-league/default.nix
+++ b/pkgs/rocket-league/default.nix
@@ -57,12 +57,11 @@
     categories = ["Game"];
   };
 
-  bakkesmod = callPackage ./bakkesmod.nix {location = location; wine = wine;};
-
-in 
-symlinkJoin {
+  bakkesmod = callPackage ./bakkesmod.nix {inherit location wine;};
+in
+  symlinkJoin {
     name = pname;
-    paths = [desktopItems script ] ++ lib.optionals enableBakkesmod [ bakkesmod ];
+    paths = [desktopItems script] ++ lib.optionals enableBakkesmod [bakkesmod];
 
     meta = {
       description = "Rocket League installer and runner (using legendary)";

--- a/pkgs/rocket-league/default.nix
+++ b/pkgs/rocket-league/default.nix
@@ -11,6 +11,8 @@
   location ? "$HOME/Games/${pname}",
   tricks ? ["arial" "cjkfonts" "vcrun2019" "d3dcompiler_43" "d3dcompiler_47" "d3dx9"],
   dxvk_hud ? "compiler",
+  callPackage,
+  enableBakkesmod ? false,
 }: let
   icon = builtins.fetchurl {
     # original url = "https://www.pngkey.com/png/full/16-160666_rocket-league-png.png";
@@ -54,10 +56,13 @@
     desktopName = "Rocket League";
     categories = ["Game"];
   };
-in
-  symlinkJoin {
+
+  bakkesmod = callPackage ./bakkesmod.nix {location = location; wine = wine;};
+
+in 
+symlinkJoin {
     name = pname;
-    paths = [desktopItems script];
+    paths = [desktopItems script ] ++ lib.optionals enableBakkesmod [ bakkesmod ];
 
     meta = {
       description = "Rocket League installer and runner (using legendary)";


### PR DESCRIPTION
Bakkesmod is a very popular mod for Rocket League, it lets you practice more effectively, allows you to change car decals, and lets you install and run extra mods.

I added bakkesmod alongside `nix-gaming#rocket-league` to my config a while ago and using it without issues for some time, I believe other `nix-gaming` users might benefit from it as well hence I am creating this PR.

My nix skills are not so advanced, so if you see possible improvements, feel free to improve them. For example, both the newly added `bakkesmod.nix` file and previously existing `rocket-league/default.nix` file share some parameters such as location and wine, ideally they should be the same, but since they are in different files I am not sure how I could achieve that. Maybe it makes sense to just add another parameter within `rocket-league/default.nix` something like `installBakkesmod ? false`, which then manages the install and executable for bakkesmod if it is set to `true`.

### Usage
If the bakkesmod was not installed within the prefix before, it will fetch the installer and run the graphical installer. After that, the user can just start bakkesmod alongside Rocket League. Don't forget to go to `Settings` and uncheck the `Enable safe mode`, then, if Rocket League is running it will ask whether it should inject, click `Yes`, and now you should be able to access bakkesmod in the game by pressing F2.
![image](https://github.com/fufexan/nix-gaming/assets/25988594/c1a270d6-c956-4bcc-9389-a4d0c7e3fc73)
