### PR TITLE
Update Star Citizen: Add UmU

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
           - wine-ge
           - wine-osu
           - wine-tkg
+          - umu
 
     uses: ./.github/workflows/nix.yml
     with:

--- a/flake.lock
+++ b/flake.lock
@@ -49,7 +49,32 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "umu": "umu"
+      }
+    },
+    "umu": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "dir": "packaging/nix",
+        "lastModified": 1721334103,
+        "narHash": "sha256-WRfHP1Ud5koDOctnbCEitT3aC5P+dxBioXAPvqLofP0=",
+        "ref": "refs/heads/main",
+        "rev": "845da38a0088a2c6325be9fa4fb9ab542db3887f",
+        "revCount": 677,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging/nix"
+      },
+      "original": {
+        "dir": "packaging/nix",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging/nix"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    umu = {
+      url = "git+https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging\/nix&submodules=1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {self, ...} @ inputs:

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -32,6 +32,7 @@
           // extra))
         .${wine};
     in {
+      umu = inputs.umu.packages.${system}.umu;
       dxvk = pkgs.callPackage ./dxvk {inherit pins;};
       dxvk-w32 = pkgs.pkgsCross.mingw32.callPackage ./dxvk {inherit pins;};
       dxvk-w64 = pkgs.pkgsCross.mingwW64.callPackage ./dxvk {inherit pins;};
@@ -84,7 +85,10 @@
 
       rocket-league = pkgs.callPackage ./rocket-league {wine = config.packages.wine-tkg;};
 
-      star-citizen = pkgs.callPackage ./star-citizen {wine = config.packages.wine-ge;};
+      star-citizen = pkgs.callPackage ./star-citizen {
+        wine = config.packages.wine-ge;
+        inherit (config.packages) umu;
+      };
 
       technic-launcher = pkgs.callPackage ./technic-launcher {};
 

--- a/pkgs/star-citizen/README.md
+++ b/pkgs/star-citizen/README.md
@@ -32,7 +32,12 @@ WINEPREFIX=$HOME/Games/star-citizen nix run github:fufexan/nix-gaming#wine-ge --
 
 ## Additional Overrides
 
-This package has an additional override `wineDllOverrides`
+This package has an additional overrides
+
+- `wineDllOverrides` (not compatible with useUmu)
+- `tricks` additional wine tricks (non-umu only)
+- `protonPath` Proton compatibility tool if umu is used. use Ge-Proton for latest
+- `protonVerbs`
 
 Example:
 
@@ -42,6 +47,8 @@ star-citizen = pkgs.star-citizen.override (prev: {
   wineDllOverrides = prev.wineDllOverrides ++ [ "dxgi=n" ];
 })
 ```
+
+Example:
 
 ### Credits
 


### PR DESCRIPTION
This is draft PR for migrating to umu at least for star-citizen to resolve #151 
Currently doesn't run (but does build) due to how umu is packaged in their flake

Star Citizen Updates:

• Add attr "useUmu" to support umu:
• Add attr protonPath to set umu's proton version:
    This defaults to proton-ge-bin in nixpkgs. To always use the latest
    proton-ge you can set this to "GE-Proton"
• Add attr protonVerbs to set proton verbs, only affects umu

Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/02923630b89aa1ab36ef8e422501a6f4fd4b2016?narHash=sha256-OhysviwHQz4p2HZL4g7XGMLoUbWMjkMr/ogaR3VUYNA%3D' (2024-05-18)
  → 'github:NixOS/nixpkgs/9355fa86e6f27422963132c2c9aeedb0fb963d93?narHash=sha256-%2B%2BTYlGMAJM1Q%2B0nMVaWBSEvEUjRs7ZGiNQOpqbQApCU%3D' (2024-07-16)
• Added input 'umu':
    'git+https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging/nix&ref=refs/heads/main&rev=ce78913d68afafca5f695f3ebb1e6a706377480d&submodules=1' (2024-07-18)
• Added input 'umu/nixpkgs':
    follows 'nixpkgs'