### PR TITLE
add: Rocket league umu

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See an overview of the flake outputs by running
 | [`faf-client`](./pkgs/faf-client)                           | Forged Alliance Forever client (multiple packages)                                                     |
 | [`osu-lazer-bin`](./pkgs/osu-lazer-bin)                     | osu! lazer, extracted from the official AppImage                                                       |
 | [`osu-stable`](./pkgs/osu-stable)                           | osu! stable version                                                                                    |
-| `rocket-league`                                             | Rocket League from Epic Games                                                                          |
+| [`rocket-league`](./pkgs/rocket-league)                     | Rocket League from Epic Games                                                                          |
 | [`star-citizen`](./pkgs/star-citizen)                       | Star Citizen                                                                                           |
 | [`technic-launcher`](./pkgs/technic-launcher)               | Technic Launcher                                                                                       |
 | [`wine-discord-ipc-bridge`](./pkgs/wine-discord-ipc-bridge) | Wine-Discord RPC Bridge                                                                                |

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -175,8 +175,7 @@
           };
 
           rocket-league = pkgs.callPackage ./rocket-league {
-            wine = config.packages.wine-tkg;
-            inherit (config.packages) eac-runtime umu-launcher-git;
+            inherit (config.packages) umu-launcher-git;
           };
 
           rpc-bridge = pkgs.callPackage ./rpc-bridge { inherit pins; };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -176,7 +176,7 @@
 
           rocket-league = pkgs.callPackage ./rocket-league {
             wine = config.packages.wine-tkg;
-            inherit (config.packages) eac-runtime;
+            inherit (config.packages) eac-runtime umu-launcher-git;
           };
 
           rpc-bridge = pkgs.callPackage ./rpc-bridge { inherit pins; };

--- a/pkgs/rocket-league/README.md
+++ b/pkgs/rocket-league/README.md
@@ -1,0 +1,55 @@
+# Rocket League
+
+Installer for Epic Games version of [Rocket League](https://www.rocketleague.com/). [legendary](https://github.com/derrod/legendary) is used for authentication and launching the game.
+
+## How to use
+Make sure you have logged in with legendary, you don't have to have legendary available in your system, if that is the case, you can temporarily enable it and log in;
+```bash
+$ nix shell nixpkgs#legendary-gl
+$ legendary auth
+```
+
+After logging in you can add rocket-league to your `home.packages` or `environment.systemPackages` by adding `nix-gaming` to your inputs.
+
+You can run the game through multiple runners, the default runner is `wine-tkg` however you can override it like that; 
+
+```nix
+  home-manager.users.emrebicer = {
+    home.packages = with pkgs; [
+      (inputs.nix-gaming.packages.${pkgs.system}.rocket-league.override {
+        wine = "${inputs.nix-gaming.packages.${pkgs.system}.wine-ge}";
+      })
+    ];
+  };
+```
+
+After executing `nixos-rebuild switch` you should have `rocket-league` available to your system.
+
+## Enabling bakkesmod
+
+You can enable bakkesmod by overriding rocket-league like that;
+```nix
+  home-manager.users.emrebicer = {
+    home.packages = with pkgs; [
+      (inputs.nix-gaming.packages.${pkgs.system}.rocket-league.override {
+        enableBakkesmod = true;
+      })
+    ];
+  };
+```
+
+After rebuilding, `bakkesmod` will be available to your system, just run bakkesmod once to install it, don't create a desktop item and finish the installation. Then you should be able to run bakkesmod and Rocket League at the same time. If bakkesmod does not inject automatically make sure to disable `Safe mode` through bakkesmod settings.
+
+## Running with umu instead of wine
+If you want to use [umu-launcher](https://github.com/Open-Wine-Components/umu-launcher) to run Rocket League, you can do so by overriding `useUmu` like that;
+```nix
+  home-manager.users.emrebicer = {
+    home.packages = with pkgs; [
+      (inputs.nix-gaming.packages.${pkgs.system}.rocket-league.override {
+        useUmu = true;
+      })
+    ];
+  };
+```
+
+If `useUmu` is set to true, wine option will be ignored.

--- a/pkgs/rocket-league/README.md
+++ b/pkgs/rocket-league/README.md
@@ -11,19 +11,11 @@ $ legendary auth
 
 After logging in you can add rocket-league to your `home.packages` or `environment.systemPackages` by adding `nix-gaming` to your inputs.
 
-You can run the game through multiple runners, the default runner is `wine-tkg` however you can override it like that; 
-
-```nix
-  home-manager.users.emrebicer = {
-    home.packages = with pkgs; [
-      (inputs.nix-gaming.packages.${pkgs.system}.rocket-league.override {
-        wine = "${inputs.nix-gaming.packages.${pkgs.system}.wine-ge}";
-      })
-    ];
-  };
-```
-
 After executing `nixos-rebuild switch` you should have `rocket-league` available to your system.
+
+# Bakkesmod
+
+Bakkesmod would only work with EAC disabled, however an [upstream bug](https://github.com/Open-Wine-Components/umu-launcher/issues/194) prevents running bakkesmod and rocket-league at the same time, so for the time being bakkesmod does not work through nix-gaming.
 
 ## Enabling bakkesmod
 
@@ -33,23 +25,10 @@ You can enable bakkesmod by overriding rocket-league like that;
     home.packages = with pkgs; [
       (inputs.nix-gaming.packages.${pkgs.system}.rocket-league.override {
         enableBakkesmod = true;
+        enableEAC = false;
       })
     ];
   };
 ```
 
 After rebuilding, `bakkesmod` will be available to your system, just run bakkesmod once to install it, don't create a desktop item and finish the installation. Then you should be able to run bakkesmod and Rocket League at the same time. If bakkesmod does not inject automatically make sure to disable `Safe mode` through bakkesmod settings.
-
-## Running with umu instead of wine
-If you want to use [umu-launcher](https://github.com/Open-Wine-Components/umu-launcher) to run Rocket League, you can do so by overriding `useUmu` like that;
-```nix
-  home-manager.users.emrebicer = {
-    home.packages = with pkgs; [
-      (inputs.nix-gaming.packages.${pkgs.system}.rocket-league.override {
-        useUmu = true;
-      })
-    ];
-  };
-```
-
-If `useUmu` is set to true, wine option will be ignored.

--- a/pkgs/rocket-league/bakkesmod.nix
+++ b/pkgs/rocket-league/bakkesmod.nix
@@ -37,6 +37,7 @@ let
     ${
       if useUmu then
         ''
+          export WINEPREFIX="${location}"
           export GAMEID=umu-252950
           export STORE=egs
           export PROTON_VERB=runinprefix
@@ -71,6 +72,7 @@ let
     ${
       if useUmu then
         ''
+          export WINEPREFIX="${location}"
           export GAMEID=umu-252950
           export STORE=egs
           export PROTON_VERB=runinprefix

--- a/pkgs/rocket-league/bakkesmod.nix
+++ b/pkgs/rocket-league/bakkesmod.nix
@@ -8,6 +8,8 @@
   wine,
   pname ? "rocket-league",
   location ? "$HOME/Games/${pname}",
+  umu-launcher-git,
+  useUmu,
 }:
 let
   bakkesmodIcon = fetchurl {
@@ -16,7 +18,11 @@ let
     sha256 = "18n6hcab25n9i4v2vmq6p8v7ii17p4x9i9jx3b300lfqm56239y7";
   };
 
-  bakkesmodExePath = "${location}/drive_c/Program Files/BakkesMod/BakkesMod.exe";
+  bakkesmodExePath =
+    if useUmu then
+      "$HOME/Games/umu/umu-252950/drive_c/Program Files/BakkesMod/BakkesMod.exe"
+    else
+      "${location}/drive_c/Program Files/BakkesMod/BakkesMod.exe";
 
   bakkesmodInstaller = writeShellScriptBin "install-bakkesmod" ''
     # Create a temp dir for the installer file
@@ -28,7 +34,22 @@ let
     ${unzip}/bin/unzip $TEMP_DIR/BakkesModSetup.zip -d $TEMP_DIR
 
     # Run the bakkesmod installer
-    WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine $TEMP_DIR/BakkesModSetup.exe
+    ${
+      if useUmu then
+        ''
+          export GAMEID=umu-252950
+          export STORE=egs
+          export PROTON_VERB=runinprefix
+
+          PATH=${umu-launcher-git}/bin:$PATH
+
+          umu-run $TEMP_DIR/BakkesModSetup.exe
+        ''
+      else
+        ''
+          WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine $TEMP_DIR/BakkesModSetup.exe
+        ''
+    }
 
     # Clean up
     rm $TEMP_DIR/BakkesModSetup.zip
@@ -46,8 +67,23 @@ let
     fi
 
     echo "Starting bakkesmod..."
-    WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine c:/Program\ Files/BakkesMod/BakkesMod.exe
 
+    ${
+      if useUmu then
+        ''
+          export GAMEID=umu-252950
+          export STORE=egs
+          export PROTON_VERB=runinprefix
+
+          PATH=${umu-launcher-git}/bin:$PATH
+
+          umu-run c:/Program\ Files/BakkesMod/BakkesMod.exe
+        ''
+      else
+        ''
+          WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine c:/Program\ Files/BakkesMod/BakkesMod.exe
+        ''
+    }
   '';
 
   bakkesmodDesktopItem = makeDesktopItem {

--- a/pkgs/rocket-league/bakkesmod.nix
+++ b/pkgs/rocket-league/bakkesmod.nix
@@ -17,7 +17,7 @@ let
     sha256 = "18n6hcab25n9i4v2vmq6p8v7ii17p4x9i9jx3b300lfqm56239y7";
   };
 
-  bakkesmodExePath = "$HOME/Games/umu/umu-252950/drive_c/Program Files/BakkesMod/BakkesMod.exe";
+  bakkesmodExePath = "${location}/drive_c/Program Files/BakkesMod/BakkesMod.exe";
 
   bakkesmodInstaller = writeShellScriptBin "install-bakkesmod" ''
     # Create a temp dir for the installer file

--- a/pkgs/rocket-league/bakkesmod.nix
+++ b/pkgs/rocket-league/bakkesmod.nix
@@ -8,6 +8,7 @@
   pname ? "rocket-league",
   location ? "$HOME/Games/${pname}",
   umu-launcher-git,
+  umuProtonPath,
 }:
 let
   bakkesmodIcon = fetchurl {
@@ -33,6 +34,7 @@ let
       export GAMEID=umu-252950
       export STORE=egs
       export PROTON_VERB=runinprefix
+      export PROTONPATH=${umuProtonPath}
 
       PATH=${umu-launcher-git}/bin:$PATH
 
@@ -61,6 +63,7 @@ let
       export GAMEID=umu-252950
       export STORE=egs
       export PROTON_VERB=runinprefix
+      export PROTONPATH=${umuProtonPath}
 
       PATH=${umu-launcher-git}/bin:$PATH
 

--- a/pkgs/rocket-league/bakkesmod.nix
+++ b/pkgs/rocket-league/bakkesmod.nix
@@ -5,11 +5,9 @@
   writeShellScriptBin,
   fetchurl,
   unzip,
-  wine,
   pname ? "rocket-league",
   location ? "$HOME/Games/${pname}",
   umu-launcher-git,
-  useUmu,
 }:
 let
   bakkesmodIcon = fetchurl {
@@ -18,11 +16,7 @@ let
     sha256 = "18n6hcab25n9i4v2vmq6p8v7ii17p4x9i9jx3b300lfqm56239y7";
   };
 
-  bakkesmodExePath =
-    if useUmu then
-      "$HOME/Games/umu/umu-252950/drive_c/Program Files/BakkesMod/BakkesMod.exe"
-    else
-      "${location}/drive_c/Program Files/BakkesMod/BakkesMod.exe";
+  bakkesmodExePath = "$HOME/Games/umu/umu-252950/drive_c/Program Files/BakkesMod/BakkesMod.exe";
 
   bakkesmodInstaller = writeShellScriptBin "install-bakkesmod" ''
     # Create a temp dir for the installer file
@@ -34,23 +28,16 @@ let
     ${unzip}/bin/unzip $TEMP_DIR/BakkesModSetup.zip -d $TEMP_DIR
 
     # Run the bakkesmod installer
-    ${
-      if useUmu then
-        ''
-          export WINEPREFIX="${location}"
-          export GAMEID=umu-252950
-          export STORE=egs
-          export PROTON_VERB=runinprefix
+    ${''
+      export WINEPREFIX="${location}"
+      export GAMEID=umu-252950
+      export STORE=egs
+      export PROTON_VERB=runinprefix
 
-          PATH=${umu-launcher-git}/bin:$PATH
+      PATH=${umu-launcher-git}/bin:$PATH
 
-          umu-run $TEMP_DIR/BakkesModSetup.exe
-        ''
-      else
-        ''
-          WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine $TEMP_DIR/BakkesModSetup.exe
-        ''
-    }
+      umu-run $TEMP_DIR/BakkesModSetup.exe
+    ''}
 
     # Clean up
     rm $TEMP_DIR/BakkesModSetup.zip
@@ -69,23 +56,16 @@ let
 
     echo "Starting bakkesmod..."
 
-    ${
-      if useUmu then
-        ''
-          export WINEPREFIX="${location}"
-          export GAMEID=umu-252950
-          export STORE=egs
-          export PROTON_VERB=runinprefix
+    ${''
+      export WINEPREFIX="${location}"
+      export GAMEID=umu-252950
+      export STORE=egs
+      export PROTON_VERB=runinprefix
 
-          PATH=${umu-launcher-git}/bin:$PATH
+      PATH=${umu-launcher-git}/bin:$PATH
 
-          umu-run c:/Program\ Files/BakkesMod/BakkesMod.exe
-        ''
-      else
-        ''
-          WINEPREFIX="${location}" WINEFSYNC=1 ${wine}/bin/wine c:/Program\ Files/BakkesMod/BakkesMod.exe
-        ''
-    }
+      umu-run c:/Program\ Files/BakkesMod/BakkesMod.exe
+    ''}
   '';
 
   bakkesmodDesktopItem = makeDesktopItem {

--- a/pkgs/rocket-league/default.nix
+++ b/pkgs/rocket-league/default.nix
@@ -46,16 +46,16 @@ let
         ''
           export GAMEID=umu-252950
           export STORE=egs
-          export PROTON_VERB=runinprefix
+          export PROTONPATH=GE-Proton
+          ${lib.optionalString enableBakkesmod "export PROTON_VERB=runinprefix"}
 
           PATH=${umu-launcher-git}/bin:${legendary-gl}/bin:${gamemode}:$PATH
 
-          legendary update Sugar --base-path ${location}
+          legendary update Sugar --base-path "$WINEPREFIX"
           legendary launch Sugar --no-wine --wrapper "gamemoderun umu-run"
         ''
       else
         ''
-          export WINEPREFIX="${location}"
           export MESA_GL_VERSION_OVERRIDE=4.4COMPAT
           export WINEFSYNC=1
           export WINEESYNC=1

--- a/pkgs/rocket-league/default.nix
+++ b/pkgs/rocket-league/default.nix
@@ -6,6 +6,7 @@
   writeShellScriptBin,
   gamemode,
   legendary-gl,
+  umu-launcher-git,
   winetricks,
   wine,
   eac-runtime,
@@ -23,6 +24,7 @@
   callPackage,
   enableEAC ? true,
   enableBakkesmod ? false,
+  useUmu ? false,
 }:
 let
   icon = fetchurl {
@@ -36,26 +38,42 @@ let
   tricksString = with builtins; if (length tricks) > 0 then concatStringsSep " " tricks else "-V";
 
   script = writeShellScriptBin pname ''
-    export WINEPREFIX="${location}"
     export DXVK_HUD=${dxvk_hud}
-    export MESA_GL_VERSION_OVERRIDE=4.4COMPAT
-    export WINEFSYNC=1
-    export WINEESYNC=1
-    export __GL_SHADER_DISK_CACHE=1
-    export __GL_SHADER_DISK_CACHE_PATH="${location}"
     ${lib.optionalString enableEAC "export PROTON_EAC_RUNTIME=\"${eac-runtime}\""}
+    ${
+      if useUmu then
+        ''
+          export GAMEID=umu-252950
+          export STORE=egs
+          export PROTON_VERB=runinprefix
 
-    PATH=${wine}/bin:${winetricks}/bin:${legendary-gl}/bin:${gamemode}:$PATH
+          PATH=${umu-launcher-git}/bin:${legendary-gl}/bin:${gamemode}:$PATH
 
-    if [ ! -d "$WINEPREFIX" ]; then
-      # install tricks
-      winetricks -q ${tricksString}
-      wineserver -k
-    fi
+          legendary update Sugar --base-path ${location}
+          legendary launch Sugar --no-wine --wrapper "gamemoderun umu-run"
+        ''
+      else
+        ''
+          export WINEPREFIX="${location}"
+          export MESA_GL_VERSION_OVERRIDE=4.4COMPAT
+          export WINEFSYNC=1
+          export WINEESYNC=1
+          export __GL_SHADER_DISK_CACHE=1
+          export __GL_SHADER_DISK_CACHE_PATH="${location}"
 
-    legendary update Sugar --base-path ${location}
-    gamemoderun legendary launch Sugar --base-path ${location}
-    wineserver -w
+          PATH=${wine}/bin:${winetricks}/bin:${legendary-gl}/bin:${gamemode}:$PATH
+
+          if [ ! -d "$WINEPREFIX" ]; then
+            # install tricks
+            winetricks -q ${tricksString}
+            wineserver -k
+          fi
+
+          legendary update Sugar --base-path ${location}
+          gamemoderun legendary launch Sugar --base-path ${location}
+          wineserver -w
+        ''
+    }
   '';
 
   desktopItems = makeDesktopItem {
@@ -66,7 +84,14 @@ let
     categories = [ "Game" ];
   };
 
-  bakkesmod = callPackage ./bakkesmod.nix { inherit location wine; };
+  bakkesmod = callPackage ./bakkesmod.nix {
+    inherit
+      location
+      wine
+      umu-launcher-git
+      useUmu
+      ;
+  };
 in
 symlinkJoin {
   name = pname;

--- a/pkgs/rocket-league/default.nix
+++ b/pkgs/rocket-league/default.nix
@@ -57,6 +57,8 @@ let
       ;
   };
 in
+assert lib.assertMsg (!enableBakkesmod)
+  "The option `enableBakkesmod` is set to `true`. BakkesMod does not work through umu yet. See https://github.com/Open-Wine-Components/umu-launcher/issues/283.";
 symlinkJoin {
   name = pname;
   paths = [

--- a/pkgs/rocket-league/default.nix
+++ b/pkgs/rocket-league/default.nix
@@ -39,7 +39,6 @@ let
 
   script = writeShellScriptBin pname ''
     export DXVK_HUD=${dxvk_hud}
-    ${lib.optionalString enableEAC "export PROTON_EAC_RUNTIME=\"${eac-runtime}\""}
     export WINEPREFIX="${location}"
     ${
       if useUmu then
@@ -52,7 +51,7 @@ let
           PATH=${umu-launcher-git}/bin:${legendary-gl}/bin:${gamemode}:$PATH
 
           legendary update Sugar --base-path "$WINEPREFIX"
-          legendary launch Sugar --no-wine --wrapper "gamemoderun umu-run"
+          legendary launch Sugar --no-wine --wrapper "gamemoderun umu-run"${lib.optionalString (!enableEAC) " -noeac"}
         ''
       else
         ''
@@ -71,7 +70,7 @@ let
           fi
 
           legendary update Sugar --base-path ${location}
-          gamemoderun legendary launch Sugar --base-path ${location}
+          gamemoderun legendary launch Sugar --base-path ${location}${lib.optionalString (!enableEAC) " -noeac"}
           wineserver -w
         ''
     }

--- a/pkgs/rocket-league/default.nix
+++ b/pkgs/rocket-league/default.nix
@@ -7,24 +7,12 @@
   gamemode,
   legendary-gl,
   umu-launcher-git,
-  winetricks,
-  wine,
-  eac-runtime,
   pname ? "rocket-league",
-  tricks ? [
-    "arial"
-    "cjkfonts"
-    "vcrun2019"
-    "d3dcompiler_43"
-    "d3dcompiler_47"
-    "d3dx9"
-  ],
-  location ? (if useUmu then "$HOME/Games/umu/umu-252950" else "$HOME/Games/${pname}"),
+  location ? "$HOME/Games/umu/umu-252950",
   dxvk_hud ? "compiler",
   callPackage,
   enableEAC ? true,
   enableBakkesmod ? false,
-  useUmu ? false,
 }:
 let
   icon = fetchurl {
@@ -34,46 +22,22 @@ let
     sha256 = "0a9ayr3vwsmljy7dpf8wgichsbj4i4wrmd8awv2hffab82fz4ykb";
   };
 
-  # concat winetricks args
-  tricksString = with builtins; if (length tricks) > 0 then concatStringsSep " " tricks else "-V";
-
   script = writeShellScriptBin pname ''
     export DXVK_HUD=${dxvk_hud}
     export WINEPREFIX="${location}"
-    ${
-      if useUmu then
-        ''
-          export GAMEID=umu-252950
-          export STORE=egs
-          export PROTONPATH=GE-Proton
-          ${lib.optionalString enableBakkesmod "export PROTON_VERB=runinprefix"}
+    ${''
+      export GAMEID=umu-252950
+      export STORE=egs
+      export PROTONPATH=GE-Proton
+      ${lib.optionalString enableBakkesmod "export PROTON_VERB=runinprefix"}
 
-          PATH=${umu-launcher-git}/bin:${legendary-gl}/bin:${gamemode}:$PATH
+      PATH=${umu-launcher-git}/bin:${legendary-gl}/bin:${gamemode}:$PATH
 
-          legendary update Sugar --base-path "$WINEPREFIX"
-          legendary launch Sugar --no-wine --wrapper "gamemoderun umu-run"${lib.optionalString (!enableEAC) " -noeac"}
-        ''
-      else
-        ''
-          export MESA_GL_VERSION_OVERRIDE=4.4COMPAT
-          export WINEFSYNC=1
-          export WINEESYNC=1
-          export __GL_SHADER_DISK_CACHE=1
-          export __GL_SHADER_DISK_CACHE_PATH="${location}"
-
-          PATH=${wine}/bin:${winetricks}/bin:${legendary-gl}/bin:${gamemode}:$PATH
-
-          if [ ! -d "$WINEPREFIX" ]; then
-            # install tricks
-            winetricks -q ${tricksString}
-            wineserver -k
-          fi
-
-          legendary update Sugar --base-path ${location}
-          gamemoderun legendary launch Sugar --base-path ${location}${lib.optionalString (!enableEAC) " -noeac"}
-          wineserver -w
-        ''
-    }
+      legendary update Sugar --base-path "$WINEPREFIX"
+      legendary launch Sugar --no-wine --wrapper "gamemoderun umu-run"${
+        lib.optionalString (!enableEAC) " -noeac"
+      }
+    ''}
   '';
 
   desktopItems = makeDesktopItem {
@@ -87,9 +51,7 @@ let
   bakkesmod = callPackage ./bakkesmod.nix {
     inherit
       location
-      wine
       umu-launcher-git
-      useUmu
       ;
   };
 in

--- a/pkgs/rocket-league/default.nix
+++ b/pkgs/rocket-league/default.nix
@@ -11,7 +11,6 @@
   wine,
   eac-runtime,
   pname ? "rocket-league",
-  location ? "$HOME/Games/${pname}",
   tricks ? [
     "arial"
     "cjkfonts"

--- a/pkgs/rocket-league/default.nix
+++ b/pkgs/rocket-league/default.nix
@@ -13,6 +13,7 @@
   callPackage,
   enableEAC ? true,
   enableBakkesmod ? false,
+  umuProtonPath ? "GE-Proton",
 }:
 let
   icon = fetchurl {
@@ -28,7 +29,7 @@ let
     ${''
       export GAMEID=umu-252950
       export STORE=egs
-      export PROTONPATH=GE-Proton
+      export PROTONPATH=${umuProtonPath}
       ${lib.optionalString enableBakkesmod "export PROTON_VERB=runinprefix"}
 
       PATH=${umu-launcher-git}/bin:${legendary-gl}/bin:${gamemode}:$PATH
@@ -52,6 +53,7 @@ let
     inherit
       location
       umu-launcher-git
+      umuProtonPath
       ;
   };
 in

--- a/pkgs/rocket-league/default.nix
+++ b/pkgs/rocket-league/default.nix
@@ -20,6 +20,7 @@
     "d3dcompiler_47"
     "d3dx9"
   ],
+  location ? (if useUmu then "$HOME/Games/umu/umu-252950" else "$HOME/Games/${pname}"),
   dxvk_hud ? "compiler",
   callPackage,
   enableEAC ? true,
@@ -40,6 +41,7 @@ let
   script = writeShellScriptBin pname ''
     export DXVK_HUD=${dxvk_hud}
     ${lib.optionalString enableEAC "export PROTON_EAC_RUNTIME=\"${eac-runtime}\""}
+    export WINEPREFIX="${location}"
     ${
       if useUmu then
         ''


### PR DESCRIPTION
After seeing the discussion at #151 and PR #193, I wanted to introduce Umu to Rocket League as well. Finally, I had some free time and made Rocket League work with Umu. 

However, there is still an issue that I could not find a solution to yet. If I enable umu, I can run bakkesmod alongside rocket-league, however once bakkesmod tries to inject, it fails and gives an error message that goes `Injection failed, please download vc_redist.x86.exe and restart your PC`. A Google search made me believe that the error message is implying I should have `Microsoft Visual C++ Redistributable` in the prefix, however even after trying to install `vcrun2019` with winetricks  (`umu-run winetricks vcrun2019`) or manually running the installer.exe (VC_redist.x86.exe or x64) in the prefix through umu, I still get the same error message bakkesmod.

I have been looking into possible solutions but could not get far. I wonder if anyone here has a suggestion to find a solution for that.

So **TLDR**; RL works with umu, and bakkesmod runs but does not inject. Any ideas on how can I fix that?