### PR TITLE
osu-lazer-bin: ensure that Velopack is disabled

### DIFF
--- a/pkgs/osu-lazer-bin/default.nix
+++ b/pkgs/osu-lazer-bin/default.nix
@@ -66,6 +66,7 @@
       makeWrapper $out/lib/osu/osu\! $out/bin/osu-lazer \
         --set COMPlus_GCGen0MaxBudget "600000" \
         --set PIPEWIRE_LATENCY "${pipewire_latency}" \
+        --set OSU_EXTERNAL_UPDATE_PROVIDER "1" \
         --set vblank_mode "0" \
         --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}"
       ${


### PR DESCRIPTION
With recent update shenanigans occuring with upstream and Velopack on Linux recently, and due to how Nix works, it's preffered to disable auto-updating.

This is already done on the nixpkgs derivation.