### PR TITLE
Fix osu!lazer updates

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -90,21 +90,6 @@
       "url": "https://api.github.com/repos/FAForever/uid/tarball/v4.0.6",
       "hash": "04wv34zwi4x08ss4pq1l3bf0rr8chg3bbia7k0yz3g4nwnrffmzg"
     },
-    "osu": {
-      "type": "GitRelease",
-      "repository": {
-        "type": "GitHub",
-        "owner": "ppy",
-        "repo": "osu"
-      },
-      "pre_releases": false,
-      "version_upper_bound": null,
-      "release_prefix": null,
-      "version": "2024.1122.0",
-      "revision": "6a0ac4c29eca22bdfe134cdd5e51395bbd6e1d49",
-      "url": "https://api.github.com/repos/ppy/osu/tarball/2024.1122.0",
-      "hash": "1hyap9rby199lgrz2a81lhdkkpa3hp0qjhsvw2j3br7qkcfabs6d"
-    },
     "proton-osu": {
       "type": "GitRelease",
       "repository": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -57,7 +57,6 @@
       osu-mime = pkgs.callPackage ./osu-mime {};
 
       osu-lazer-bin = pkgs.callPackage ./osu-lazer-bin {
-        inherit pins;
         inherit (config.packages) osu-mime;
       };
 

--- a/pkgs/osu-lazer-bin/default.nix
+++ b/pkgs/osu-lazer-bin/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pins,
   SDL2,
   alsa-lib,
   appimageTools,
@@ -28,7 +27,7 @@
   osu-mime,
 }: let
   pname = "osu-lazer-bin";
-  inherit (pins.osu) version;
+  inherit (builtins.fromJSON (builtins.readFile ./info.json)) version;
 
   appimageBin = fetchurl {
     url = "https://github.com/ppy/osu/releases/download/${version}/osu.AppImage";

--- a/pkgs/osu-lazer-bin/update.sh
+++ b/pkgs/osu-lazer-bin/update.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env -S nix shell nixpkgs#jq -c bash
+#!/usr/bin/env -S nix shell nixpkgs#curl nixpkgs#jq -c bash
 
 info="pkgs/osu-lazer-bin/info.json"
-version=$(jq -r '.pins.osu.version' npins/sources.json)
+version=$(curl -s "https://api.github.com/repos/ppy/osu/releases/latest" | jq -r '.tag_name')
 oldversion=$(jq -r '.version' "$info")
 url="https://github.com/ppy/osu/releases/download/${version}/osu.AppImage"
 
@@ -9,7 +9,7 @@ if [ "$oldversion" != "$version" ]; then
   if output=$(nix store prefetch-file "$url" --json); then
     jq --arg version "$version" '.version = $version' <<<"$output" >"$info"
   else
-    echo "osu!lazer has a non-release update"
+    echo "Failed to fetch new osu!lazer binary, possibly non-release update"
   fi
 else
   echo "osu!lazer is up to date."

--- a/pkgs/osu-lazer-bin/update.sh
+++ b/pkgs/osu-lazer-bin/update.sh
@@ -9,7 +9,7 @@ if [ "$oldversion" != "$version" ]; then
   if output=$(nix store prefetch-file "$url" --json); then
     jq --arg version "$version" '.version = $version' <<<"$output" >"$info"
   else
-    echo "Failed to fetch new osu!lazer binary, possibly non-release update"
+    echo "osu!lazer has a non-release update"
   fi
 else
   echo "osu!lazer is up to date."


### PR DESCRIPTION
osu!lazer has been pushing more than a few tags without release artifacts recently. This tends to break builds because while the `info.json` file is updated properly, the version is still fetched from npins directly, causing a 404.

This fixes the issue by sourcing the version from `info.json` directly to ensure that we get a tag with a release attached.