### PR TITLE
osu-lazer-bin: fix build failure due to missing icon

### DIFF
--- a/pkgs/osu-lazer-bin/default.nix
+++ b/pkgs/osu-lazer-bin/default.nix
@@ -60,7 +60,7 @@
     installPhase = ''
       runHook preInstall
       install -d $out/bin $out/lib
-      install osu\!.png $out/osu.png
+      install osu.png $out/osu.png
       cp -r usr/bin $out/lib/osu
       makeWrapper $out/lib/osu/osu\! $out/bin/osu-lazer \
         --set COMPlus_GCGen0MaxBudget "600000" \


### PR DESCRIPTION
It seems osu-lazer's icon has been renamed in the last update, breaking the build process.

This fixes #224 