### PR TITLE
proton-osu-bin: fix hash

### DIFF
--- a/pkgs/proton-osu-bin/info.json
+++ b/pkgs/proton-osu-bin/info.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-KLujOxguAh1e6Au0nICiMcem76LesDISui/sDCmuges=",
-  "storePath": "/nix/store/46cgh19ncik0xkv16zc8p128isn5a0bg-proton-osu-9-13.tar.xz",
+  "hash": "sha256-YviRhLisqblWRU9TEdZS345kDIH9gho8GatoHzqLejI=",
+  "storePath": "/nix/store/yim10ik7m4m7ky7j727l0n12xaw9v1l0-proton-osu-9-13.tar.xz",
   "version": "proton-osu-9-13"
 }


### PR DESCRIPTION
`proton-osu-bin` re-released version 9-13 with a different hash. The update script has no way to detect this right now, so the hash has to be refetched manually.

If this happens again I'll try to implement a detection system for cases like this.