### PR TITLE
umu -> umu-launcher: switch to npins & rename to umu-launcher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           - wine-ge
           - wine-osu
           - wine-tkg
-          - umu
+          - umu-launcher
 
     uses: ./.github/workflows/nix.yml
     with:

--- a/flake.lock
+++ b/flake.lock
@@ -49,32 +49,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "umu": "umu"
-      }
-    },
-    "umu": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "dir": "packaging/nix",
-        "lastModified": 1738306689,
-        "narHash": "sha256-g1p++aLe6q6OdGy3K91uyCjAeBUkkT4uoItSFQT+PJw=",
-        "ref": "refs/heads/main",
-        "rev": "7a71163b79e56222fe3f3097d1e71208a91a1a3b",
-        "revCount": 917,
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging/nix"
-      },
-      "original": {
-        "dir": "packaging/nix",
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging/nix"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,6 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    umu = {
-      url = "git+https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging\/nix&submodules=1";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs = {self, ...} @ inputs:

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -117,6 +117,18 @@
       "url": "https://github.com/GloriousEggroll/proton-wine/archive/39021e609a24b6aeffdf9c4695a286d71e7dffbc.tar.gz",
       "hash": "000d5kba7vs5nc1sc3946jkpqmch4w09qz74i5zgc7nh7znck6f8"
     },
+    "umu-launcher": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "Open-Wine-Components",
+        "repo": "umu-launcher"
+      },
+      "branch": "main",
+      "revision": "7a71163b79e56222fe3f3097d1e71208a91a1a3b",
+      "url": "https://github.com/Open-Wine-Components/umu-launcher/archive/7a71163b79e56222fe3f3097d1e71208a91a1a3b.tar.gz",
+      "hash": "1s3fblgbm9cvmv6m93lbvg48dhwjldp46yniwaffx1r7dm7sxmsg"
+    },
     "vkd3d-proton": {
       "type": "GitRelease",
       "repository": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -32,7 +32,23 @@
           // extra))
         .${wine};
     in {
-      inherit (inputs.umu.packages.${system}) umu;
+      umu = self.lib.mkDeprecated "warn" config.packages.umu-launcher {
+        name = "umu";
+        target = "package";
+        date = "2025-02-04";
+        instructions = ''
+          This package has been renamed to `umu-launcher` to
+          match the package name in nixpkgs.
+        '';
+      };
+      umu-launcher-unwrapped = pkgs.callPackage "${pins.umu-launcher}/packaging/nix/unwrapped.nix" {
+        inherit (pkgs) umu-launcher-unwrapped;
+        version = builtins.substring 0 7 pins.umu-launcher.revision;
+      };
+      umu-launcher = pkgs.callPackage "${pins.umu-launcher}/packaging/nix/package.nix" {
+        inherit (pkgs) umu-launcher;
+        inherit (config.packages) umu-launcher-unwrapped;
+      };
       dxvk = pkgs.callPackage ./dxvk {inherit pins;};
       dxvk-w32 = pkgs.pkgsCross.mingw32.callPackage ./dxvk {inherit pins;};
       dxvk-w64 = pkgs.pkgsCross.mingwW64.callPackage ./dxvk {inherit pins;};
@@ -61,7 +77,7 @@
       };
 
       osu-stable = pkgs.callPackage ./osu-stable {
-        inherit (config.packages) osu-mime proton-osu-bin umu;
+        inherit (config.packages) osu-mime proton-osu-bin umu-launcher;
         wine = config.packages.wine-osu;
         wine-discord-ipc-bridge = config.packages.wine-discord-ipc-bridge.override {wine = config.packages.wine-osu;};
       };
@@ -91,7 +107,7 @@
       star-citizen = pkgs.callPackage ./star-citizen {
         wine = pkgs.wineWowPackages.staging;
         winetricks = config.packages.winetricks-git;
-        inherit (config.packages) umu;
+        inherit (config.packages) umu-launcher;
       };
       star-citizen-umu = config.packages.star-citizen.override {useUmu = true;};
 

--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -7,12 +7,12 @@
   wine-discord-ipc-bridge,
   winetricks,
   wine,
-  umu,
+  umu-launcher,
   proton-osu-bin,
   wineFlags ? "",
   pname ? "osu-stable",
   location ? "$HOME/.osu",
-  useUmu ? false,
+  useUmu ? true,
   protonPath ? "${proton-osu-bin.steamcompattool}",
   protonVerbs ? ["waitforexitandrun"],
   tricks ? ["gdiplus" "dotnet45" "meiryo"],
@@ -47,7 +47,7 @@
     PATH=${
       lib.makeBinPath (
         if useUmu
-        then [umu]
+        then [umu-launcher]
         else [wine winetricks]
       )
     }:$PATH

--- a/pkgs/star-citizen/default.nix
+++ b/pkgs/star-citizen/default.nix
@@ -8,7 +8,7 @@
   winetricks,
   wine,
   dxvk,
-  umu,
+  umu-launcher,
   proton-ge-bin,
   wineFlags ? "",
   pname ? "star-citizen",
@@ -81,7 +81,7 @@
     PATH=${
       lib.makeBinPath (
         if useUmu
-        then [umu]
+        then [umu-launcher]
         else [wine winetricks]
       )
     }:$PATH


### PR DESCRIPTION
This pull request resolves issue #204. Following the upstream renaming of `umu` to `umu-launcher`, I have updated the name accordingly. If you prefer this change to be implemented as a soft change for now, please let me know.

Mentioning @ProspectPyxis since this also changes `osu-stable`. I did a quick test to ensure it's working. 