### PR TITLE
osu-stable: add useGameMode option

### DIFF
--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -13,6 +13,7 @@
   pname ? "osu-stable",
   location ? "$HOME/.osu",
   useUmu ? true,
+  useGameMode ? true,
   protonPath ? "${proton-osu-bin.steamcompattool}",
   protonVerbs ? ["waitforexitandrun"],
   tricks ? ["gdiplus" "dotnet45" "meiryo"],
@@ -31,6 +32,8 @@
     if (length tricks) > 0
     then concatStringsSep " " tricks
     else "-V";
+
+  gameMode = lib.strings.optionalString useGameMode "${gamemode}/bin/gamemoderun";
 
   script = writeShellScriptBin pname ''
     export WINEARCH="win32"
@@ -88,11 +91,11 @@
     ${
       if useUmu
       then ''
-        ${gamemode}/bin/gamemoderun umu-run "$OSU" "$@"
+        ${gameMode} umu-run "$OSU" "$@"
       ''
       else ''
         wine ${wine-discord-ipc-bridge}/bin/winediscordipcbridge.exe &
-        ${gamemode}/bin/gamemoderun wine ${wineFlags} "$OSU" "$@"
+        ${gameMode} wine ${wineFlags} "$OSU" "$@"
         wineserver -w
       ''
     }


### PR DESCRIPTION
I've found that gamemode doesn't seem to play nice with osu-stable, at least when using umu - the logs are flooded with the error message `gamemodeauto: dlopen failed - libgamemode.so: cannot open shared object file: No such file or directory`, and while the game runs fine, the moment it exits, it does so with a SIGABRT.

I'm not sure what's up with this - the best assumption I have is that it's an upstream issue with gamemode and it interacting with umu strangely, somehow.

In either case, as a bandaid fix, I'm adding the `useGameMode` option, so that if you find that gamemode misbehaves, it can be disabled.