### PR TITLE
dxvk-nvapi: init at 0.9.0

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -64,6 +64,22 @@
       "url": "https://api.github.com/repos/Sporif/dxvk-async/tarball/2.0",
       "hash": "0b5vcznrir6h3vzdlylxdw63sspmqai0ah616f2nsa4nfs5y5rcr"
     },
+    "dxvk-nvapi": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "jp7677",
+        "repo": "dxvk-nvapi"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": true,
+      "version": "v0.9.0",
+      "revision": "e870088aa074b031b0f13d7d37500ca9d4834768",
+      "url": null,
+      "hash": "1g7pmlarwa6l406l1yglnksi13fhfvh8zr7qa2q4q83aiws9gk3g"
+    },
     "faf-ice-adapter": {
       "type": "GitRelease",
       "repository": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55,6 +55,10 @@
       dxvk-w32 = pkgs.pkgsCross.mingw32.callPackage ./dxvk {inherit pins;};
       dxvk-w64 = pkgs.pkgsCross.mingwW64.callPackage ./dxvk {inherit pins;};
 
+      dxvk-nvapi = pkgs.callPackage ./dxvk {inherit pins;};
+      dxvk-nvapi-w32 = pkgs.pkgsCross.mingw32.callPackage ./dxvk-nvapi {inherit pins;};
+      dxvk-nvapi-w64 = pkgs.pkgsCross.mingwW64.callPackage ./dxvk-nvapi {inherit pins;};
+
       faf-client = pkgs.callPackage ./faf-client {inherit pins;};
       faf-client-unstable = pkgs.callPackage ./faf-client {
         inherit pins;

--- a/pkgs/dxvk-nvapi/default.nix
+++ b/pkgs/dxvk-nvapi/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  pkg-config,
+  vulkan-headers,
+  ninja,
+  meson,
+  windows,
+  pins,
+}: let
+  inherit (pins) dxvk-nvapi;
+in
+  # TODO: Add dxvk-nvapi-vkreflex-layer
+  stdenv.mkDerivation {
+    pname = "dxvk-nvapi";
+    inherit (dxvk-nvapi) version;
+
+    src = dxvk-nvapi;
+
+    postPatch = ''
+      # Use Vulkan Headers from nixpkgs
+      substituteInPlace meson.build \
+        --replace-fail "./external/Vulkan-Headers/include" "${vulkan-headers}/include"
+    '';
+    strictDeps = true;
+    nativeBuildInputs = [
+      pkg-config
+      meson
+      ninja
+    ];
+    buildInputs = lib.optional stdenv.hostPlatform.isWindows windows.pthreads;
+    mesonBuildType = "release";
+    doCheck = true;
+    __structuredAttrs = true;
+
+    meta = {
+      description = "Alternative NVAPI implementation on top of DXVK";
+      homepage = "https://github.com/jp7677/dxvk-nvapi";
+      changelog = "https://github.com/jp7677/dxvk-nvapi/releases";
+      license = lib.licenses.mit;
+      badPlatforms = lib.platforms.darwin;
+      platforms = lib.platforms.unix ++ lib.platforms.windows;
+      maintainers = with lib.maintainers; [fuzen];
+    };
+  }


### PR DESCRIPTION
Initial PR to add dxvk-nvapi currently doesn't include vulkan layer for NVIDIA reflex.