### PR TITLE
dxvk-nvapi-vkreflex-layer: init at 0.9.0

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -59,6 +59,8 @@
       dxvk-nvapi-w32 = pkgs.pkgsCross.mingw32.callPackage ./dxvk-nvapi {inherit pins;};
       dxvk-nvapi-w64 = pkgs.pkgsCross.mingwW64.callPackage ./dxvk-nvapi {inherit pins;};
 
+      dxvk-nvapi-vkreflex-layer = pkgs.callPackage ./dxvk-nvapi/vkreflex-layer.nix {inherit pins;};
+
       faf-client = pkgs.callPackage ./faf-client {inherit pins;};
       faf-client-unstable = pkgs.callPackage ./faf-client {
         inherit pins;

--- a/pkgs/dxvk-nvapi/vkreflex-layer.nix
+++ b/pkgs/dxvk-nvapi/vkreflex-layer.nix
@@ -2,35 +2,31 @@
   lib,
   stdenv,
   pkg-config,
-  vulkan-headers,
+  vulkan-loader,
   ninja,
   meson,
-  windows,
   pins,
 }: let
   inherit (pins) dxvk-nvapi;
 in
   stdenv.mkDerivation {
-    pname = "dxvk-nvapi";
+    pname = "dxvk-nvapi-vkreflex-layer";
     inherit (dxvk-nvapi) version;
 
     src = dxvk-nvapi;
+    mesonFlags = ["./layer"];
 
-    postPatch = ''
-      # Use Vulkan Headers from nixpkgs
-      substituteInPlace meson.build \
-        --replace-fail "./external/Vulkan-Headers/include" "${vulkan-headers}/include"
-    '';
     strictDeps = true;
     nativeBuildInputs = [
       pkg-config
       meson
       ninja
     ];
-    buildInputs = lib.optional stdenv.hostPlatform.isWindows windows.pthreads;
+    buildInputs = [
+      vulkan-loader
+    ];
     mesonBuildType = "release";
     doCheck = true;
-    __structuredAttrs = true;
 
     meta = {
       description = "Alternative NVAPI implementation on top of DXVK";
@@ -38,7 +34,6 @@ in
       changelog = "https://github.com/jp7677/dxvk-nvapi/releases";
       license = lib.licenses.mit;
       badPlatforms = lib.platforms.darwin;
-      platforms = lib.platforms.unix ++ lib.platforms.windows;
-      maintainers = with lib.maintainers; [fuzen];
+      platforms = lib.platforms.unix;
     };
   }


### PR DESCRIPTION
I didn't use the vulkan-headers from nixpkgs because the version is too new for vkroots.
The compatibility layer appears correctly in vulkaninfo, but no further testing has been done yet.
@LovingMelody 