### PR TITLE
vkd3d-proton: use correct version info from pin metadata

### DIFF
--- a/pkgs/vkd3d-proton/default.nix
+++ b/pkgs/vkd3d-proton/default.nix
@@ -33,10 +33,14 @@ stdenv.mkDerivation {
 
   strictDeps = true;
 
-  patches = [
-    # Fixes a compiler error with mingw
-    ./explicitly_define_hex_base.patch
-  ];
+  # Manually pass pinned version info through to vcs_tag since we don't have .git
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "'git', 'describe', '--always', '--exclude=*', '--abbrev=15', '--dirty=0'" \
+      "'echo', '${builtins.substring 0 15 pins.vkd3d-proton.revision}'" \
+      --replace-fail "'git', 'describe', '--always', '--tags', '--dirty=+'" \
+      "'echo', '${pins.vkd3d-proton.version}'"
+  '';
 
   mesonFlags =
     [

--- a/pkgs/vkd3d-proton/explicitly_define_hex_base.patch
+++ b/pkgs/vkd3d-proton/explicitly_define_hex_base.patch
@@ -1,9 +1,0 @@
-diff --git a/vkd3d_build.h.in b/vkd3d_build.h.in
-index f67a25d9..e985c9e2 100644
---- a/vkd3d_build.h.in
-+++ b/vkd3d_build.h.in
-@@ -1,3 +1,3 @@
- #include <stdint.h>
- 
--static const uint64_t vkd3d_build = 0x@VCS_TAG@;
-+static const uint64_t vkd3d_build = 0x@VCS_TAG@p1;


### PR DESCRIPTION
Previously version/build were set incorrectly as there's no .git available with nix