### PR TITLE
wineprefix-preparer: add nvapi, add to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
           - wine-ge
           - wine-osu
           - wine-tkg
+          - wineprefix-preparer
           - umu-launcher
 
     uses: ./.github/workflows/nix.yml

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -147,7 +147,7 @@
 
       winetricks-git = pkgs.callPackage ./winetricks-git {inherit pins;};
 
-      wineprefix-preparer = pkgs.callPackage ./wineprefix-preparer {inherit (config.packages) dxvk-w32 vkd3d-proton-w32 dxvk-w64 vkd3d-proton-w64;};
+      wineprefix-preparer = pkgs.callPackage ./wineprefix-preparer {inherit (config.packages) dxvk-w32 vkd3d-proton-w32 dxvk-w64 vkd3d-proton-w64 dxvk-nvapi-w32 dxvk-nvapi-w64;};
     };
   };
 }

--- a/pkgs/wineprefix-preparer/default.nix
+++ b/pkgs/wineprefix-preparer/default.nix
@@ -3,6 +3,8 @@
   dxvk-w32,
   vkd3d-proton-w64,
   vkd3d-proton-w32,
+  dxvk-nvapi-w32,
+  dxvk-nvapi-w64,
   pkgsCross,
   writeShellScriptBin,
 }:
@@ -47,6 +49,12 @@ writeShellScriptBin "wineprefix-preparer"
   echo "Installing vkd3d-proton DLLs"
   install -v -D -m644 -t "$win64_sys_path" ${vkd3d-proton-w64}/bin/*.dll
   install -v -D -m644 -t "$win32_sys_path" ${vkd3d-proton-w32}/bin/*.dll
+
+  echo "Installing dxvk-nvapi DLLs"
+  install -v -D -m644 -t "$win64_sys_path" ${dxvk-nvapi-w32}/bin/*.dll
+  install -v -D -m644 -t "$win32_sys_path" ${dxvk-nvapi-w32}/bin/*.dll
+  install -v -D -m644 -t "$win64_sys_path" ${dxvk-nvapi-w64}/bin/*.dll
+  install -v -D -m644 -t "$win32_sys_path" ${dxvk-nvapi-w64}/bin/*.dll
 
   echo "Adding native DllOverrides"
   for dll in dxgi d3d9 d3d10core d3d11 d3d12 d3d12core; do


### PR DESCRIPTION
Adding dxvk-nvapi to wineprefix-preparer.

Copying the star-citizen derivation, we install both DLLs in both locations; nvapi has a unique name per arch.  
https://github.com/fufexan/nix-gaming/blob/29ba418c6449f123b0d4319d4226e06bd2038150/pkgs/star-citizen/default.nix#L105-L108

nvapi DLLs will do nothing unless DXVK_ENABLE_NVAPI=1 is set at use time; should be safe to install unconditionally.