### PR TITLE
star-citizen: 2.3.1 -> 2.3.2

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -115,7 +115,8 @@
       star-citizen = pkgs.callPackage ./star-citizen {
         wine = config.packages.wine-tkg;
         winetricks = config.packages.winetricks-git;
-        inherit (config.packages) umu-launcher dxvk-nvapi-w32 dxvk-nvapi-w64;
+
+        inherit (config.packages) umu-launcher wineprefix-preparer;
       };
       star-citizen-umu = config.packages.star-citizen.override {useUmu = true;};
 


### PR DESCRIPTION
* `use wineprefix-preparer`
* only run gamemode if it is already present on the system
   gamemode isnt always needed and would already be present
   if it is configured correctly due to polkit rules
* Update RSI launcher from 2.3.1 to 2.3.2