### PR TITLE
faf-client: disable bwrap for update script

### DIFF
--- a/pkgs/faf-client/default.nix
+++ b/pkgs/faf-client/default.nix
@@ -165,6 +165,7 @@
       inherit pname;
       data = depsPath;
       pkg = self;
+      useBwrap = false;
     };
     __darwinAllowLocalNetworking = true;
 

--- a/pkgs/faf-client/ice-adapter.nix
+++ b/pkgs/faf-client/ice-adapter.nix
@@ -55,6 +55,7 @@
       inherit pname;
       data = ./deps-ice.json;
       pkg = self;
+      useBwrap = false;
     };
     __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
Fix #253.
According to [this](https://github.com/NixOS/nixpkgs/blob/218a02803ba5d26453f94559895f3d1b90705976/pkgs/development/tools/build-managers/gradle/update-deps.nix#L134), bwrap is not necessary for update scripts, so I simply turned it off.