### PR TITLE
mo2installer: update to furglitch fork, document steam-run usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See an overview of the flake outputs by running
 | [`wine-discord-ipc-bridge`](./pkgs/wine-discord-ipc-bridge) | Wine-Discord RPC Bridge                                                                                |
 | [`wine`](./pkgs/wine)                                       | Multiple Wine packages                                                                                 |
 | [`winestreamproxy`](./pkgs/winestreamproxy)                 | Wine-Discord RPC (broken)                                                                              |
-| [`mo2installer`](./pkgs/mo2installer)                       | RockerBacon's Mod Organizer 2 installer script                                                         |
+| [`mo2installer`](./pkgs/mo2installer)                       | Furglitch's updated Mod Organizer 2 installer script                                                   |
 | [`northstar-proton`](./pkgs/titanfall/northstar-proton.nix) | Proton build based on TKG's proton-tkg build system to run the Northstar client on Linux and SteamDeck |
 | [`viper`](./pkgs/titanfall/viper.nix)                       | Launcher+Updater for Titanfall2 Northstar Client                                                       |
 

--- a/pkgs/mo2installer/README.md
+++ b/pkgs/mo2installer/README.md
@@ -1,0 +1,9 @@
+# Mod Organizer 2 Installer
+## Current Version 2.5.2
+
+To install a Mod Organizer 2 instance on one of your steam games, run the installer with steam-run
+```bash
+steam-run mo2installer
+```
+
+From here the installation process will be the same as described on the [original installer page](https://github.com/Furglitch/modorganizer2-linux-installer)

--- a/pkgs/mo2installer/default.nix
+++ b/pkgs/mo2installer/default.nix
@@ -10,13 +10,13 @@
   stdenv,
   zenity,
 }: let
-  version = "5.0.3";
+  version = "5.1.4";
 
   src = fetchFromGitHub {
-    owner = "rockerbacon";
+    owner = "furglitch";
     repo = "modorganizer2-linux-installer";
     rev = "refs/tags/${version}";
-    hash = "sha256-RYN5/t5Hmzu+Tol9iJ+xDmLGY9sAkLTU0zY6UduJ4i0=";
+    hash = "sha256-eDrWITS0beJF653K+FhivMfwZlEBTPfB3LAjVVN2Iio=";
   };
 
   steam-redirector = callPackage ./steam-redirector.nix {inherit version src;};
@@ -67,7 +67,7 @@ in
 
     meta = {
       description = "An easy-to-use Mod Organizer 2 installer for Linux";
-      homepage = "https://github.com/rockerbacon/modorganizer2-linux-installer";
+      homepage = "https://github.com/Furglitch/modorganizer2-linux-installer";
       license = lib.licenses.gpl3Only;
       mainProgram = "mo2installer";
       platforms = lib.platforms.linux;


### PR DESCRIPTION
Fixes #247 

This still works when run through `steam-run` have documented this stipulation and updated it to use furglitch's fork as it supports latest Mod Organizer 2 release version.