### PR TITLE
osu-lazer-bin: add derivation for Tachyon releases

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -84,6 +84,11 @@
         inherit (config.packages) osu-mime;
       };
 
+      osu-lazer-tachyon-bin = pkgs.callPackage ./osu-lazer-bin {
+        inherit (config.packages) osu-mime;
+        releaseStream = "tachyon";
+      };
+
       osu-stable = pkgs.callPackage ./osu-stable {
         inherit (config.packages) osu-mime proton-osu-bin umu-launcher;
         wine = config.packages.wine-osu;

--- a/pkgs/osu-lazer-bin/default.nix
+++ b/pkgs/osu-lazer-bin/default.nix
@@ -24,14 +24,16 @@
     # won't hurt users even if they don't have it set up
     then "${gamemode}/bin/gamemoderun"
     else null,
+  releaseStream ? "lazer",
   osu-mime,
 }: let
   pname = "osu-lazer-bin";
-  inherit (builtins.fromJSON (builtins.readFile ./info.json)) version;
+  info = (builtins.fromJSON (builtins.readFile ./info.json)).${releaseStream};
+  inherit (info) version;
 
   appimageBin = fetchurl {
     url = "https://github.com/ppy/osu/releases/download/${version}/osu.AppImage";
-    inherit (builtins.fromJSON (builtins.readFile ./info.json)) hash;
+    inherit (info) hash;
   };
   extracted = appimageTools.extract {
     inherit version;

--- a/pkgs/osu-lazer-bin/info.json
+++ b/pkgs/osu-lazer-bin/info.json
@@ -1,5 +1,14 @@
 {
-  "hash": "sha256-jG3KedllnVNd5TLSkKYae2V8CzN90g5lJhT4EKI+nuk=",
-  "storePath": "/nix/store/pnxnki8ymkrcbk4k3iimlby3jh8hzljp-osu.AppImage",
-  "version": "2025.607.0"
+  "lazer": {
+    "query": "map(select(.prerelease | not)) | first | .tag_name",
+    "hash": "sha256-jG3KedllnVNd5TLSkKYae2V8CzN90g5lJhT4EKI+nuk=",
+    "storePath": "/nix/store/pnxnki8ymkrcbk4k3iimlby3jh8hzljp-osu.AppImage",
+    "version": "2025.607.0"
+  },
+  "tachyon": {
+    "query": "map(select(.prerelease)) | first | .tag_name",
+    "hash": "sha256-xLniL2fogWFAaEADvX2YL7lRGHGew7kc3Ni1fhPzs1c=",
+    "storePath": "/nix/store/n99m3kdc7axi03mkpzqjadaqgbvx9653-osu.AppImage",
+    "version": "2025.607.1"
+  }
 }

--- a/pkgs/osu-lazer-bin/update.sh
+++ b/pkgs/osu-lazer-bin/update.sh
@@ -1,16 +1,31 @@
 #!/usr/bin/env -S nix shell nixpkgs#curl nixpkgs#jq -c bash
 
-info="pkgs/osu-lazer-bin/info.json"
-version=$(curl -s "https://api.github.com/repos/ppy/osu/releases/latest" | jq -r '.tag_name')
-oldversion=$(jq -r '.version' "$info")
-url="https://github.com/ppy/osu/releases/download/${version}/osu.AppImage"
+set -eu
 
-if [ "$oldversion" != "$version" ]; then
-  if output=$(nix store prefetch-file "$url" --json); then
-    jq --arg version "$version" '.version = $version' <<<"$output" >"$info"
+info="pkgs/osu-lazer-bin/info.json"
+releases="$(curl -fsSL "https://api.github.com/repos/ppy/osu/releases")"
+
+for releaseStream in $(jq -r 'keys[]' "$info"); do
+  query=$(jq -r ".$releaseStream.query" "$info")
+  # Sort descending by creation date in case GitHub releases order gets messed up
+  version=$(jq -r "sort_by(.created_at) | reverse | $query" <<<"$releases")
+  oldversion=$(jq -r ".$releaseStream.version" "$info")
+  url="https://github.com/ppy/osu/releases/download/${version}/osu.AppImage"
+
+  if [ "$oldversion" != "$version" ]; then
+    output=$(mktemp)
+    if nix store prefetch-file "$url" --json > "$output"; then
+      newinfo=$(mktemp)
+      # Merges object of release stream with output from Nix store prefetch
+      jq -s --arg version "$version" ".[0].$releaseStream = .[0].$releaseStream + .[1] | .[0] | .$releaseStream.version = \$version" "$info" "$output" > "$newinfo"
+      cp -f "$newinfo" "$info"
+      rm "$newinfo"
+    else
+      echo "osu!lazer ($releaseStream) has a non-release update"
+    fi
+    rm "$output"
   else
-    echo "osu!lazer has a non-release update"
+    echo "osu!lazer ($releaseStream) is up to date."
   fi
-else
-  echo "osu!lazer is up to date."
-fi
+done
+


### PR DESCRIPTION
Closes #263
Addresses #261

A bit overengineered, but this ensures that both release streams are properly updated, and only when necessary.