### PR TITLE
star-citizen: 2.3.2 -> 2.5.1

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -30,6 +30,7 @@ jobs:
           pkgs/osu-stable/update.sh
           pkgs/proton-osu-bin/update.sh
           pkgs/wine/update-wine-ge.sh
+          pkgs/star-citizen/update.sh
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/pkgs/star-citizen/default.nix
+++ b/pkgs/star-citizen/default.nix
@@ -27,12 +27,13 @@
   pkgs,
 }: let
   inherit (lib.strings) concatStringsSep optionalString toShellVars;
-  # Latest version can be found: https://install.robertsspaceindustries.com/rel/2/latest.yml
-  version = "2.3.2";
+  info = builtins.fromJSON (builtins.readFile ./info.json);
+  inherit (info) version;
+
   src = pkgs.fetchurl {
     url = "https://install.robertsspaceindustries.com/rel/2/RSI%20Launcher-Setup-${version}.exe";
-    name = "RSI Launcher-Setup-${version}.exe";
-    hash = "sha256-BzsO2bHXo7axvW9enll08H5aPA1KCZSLfikE49/EUw0=";
+    name = "RSI-Launcher-Setup-${version}.exe";
+    inherit (info) hash;
   };
 
   gameScope = lib.strings.optionalString gameScopeEnable "${gamescope}/bin/gamescope ${concatStringsSep " " gameScopeArgs} --";

--- a/pkgs/star-citizen/info.json
+++ b/pkgs/star-citizen/info.json
@@ -1,0 +1,5 @@
+{
+  "version": "2.5.1",
+  "url": "https://install.robertsspaceindustries.com/rel/2/RSI%20Launcher-Setup-2.5.1.exe",
+  "hash": "sha256-TM9FPcJO0pcEM+WKC0SZC12ud6p19jZHJqPESo2Y6xg="
+}

--- a/pkgs/star-citizen/update.sh
+++ b/pkgs/star-citizen/update.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p curl yq-go jq
+
+INFO="pkgs/star-citizen/info.json"
+
+VERSION="$(curl -s 'https://install.robertsspaceindustries.com/rel/2/latest.yml' | yq -r '.version')"
+
+url="https://install.robertsspaceindustries.com/rel/2/RSI%20Launcher-Setup-$VERSION.exe"
+
+HASH="$(nix store prefetch-file "$url" --name "RSI-Launcher-Setup-$VERSION.exe" --json | jq -r .hash)"
+
+jq -n \
+        --arg version "$VERSION" \
+        --arg url "$url" \
+        --arg hash "$HASH" \
+        '{version: $version, url: $url, hash: $hash}' >"$INFO"


### PR DESCRIPTION
Bump RSI launcher installer to 2.5.1 this update includes fixes for EAC by CIG
Added update script