### PR TITLE
wine-tkg{,-ntsync}: add version update script to avoid IFD

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -31,6 +31,7 @@ jobs:
           pkgs/proton-osu-bin/update.sh
           pkgs/technic-launcher/update.sh
           pkgs/wine/update-wine-ge.sh
+          pkgs/wine/update-wine-tkg.sh
           pkgs/star-citizen/update.sh
 
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/pkgs/wine/default.nix
+++ b/pkgs/wine/default.nix
@@ -59,17 +59,17 @@ in {
   });
 
   wine-tkg = callPackage "${nixpkgs-wine}/pkgs/applications/emulators/wine/base.nix" (lib.recursiveUpdate defaults
-    rec {
+    {
       pname = pnameGen "wine-tkg";
-      version = lib.removeSuffix "\n" (lib.removePrefix "Wine version " (builtins.readFile "${src}/VERSION"));
+      version = lib.removeSuffix "\n" (lib.removePrefix "Wine version " (builtins.readFile ./wine-tkg/VERSION));
       src = pins.wine-tkg;
       monos = [wine-mono];
     });
 
   wine-tkg-ntsync = callPackage "${nixpkgs-wine}/pkgs/applications/emulators/wine/base.nix" (lib.recursiveUpdate defaults
-    rec {
+    {
       pname = pnameGen "wine-tkg-ntsync";
-      version = lib.removeSuffix "\n" (lib.removePrefix "Wine version " (builtins.readFile "${src}/VERSION"));
+      version = lib.removeSuffix "\n" (lib.removePrefix "Wine version " (builtins.readFile ./wine-tkg-ntsync/VERSION));
       src = pins.wine-tkg-ntsync;
       monos = [wine-mono];
     });

--- a/pkgs/wine/update-wine-tkg.sh
+++ b/pkgs/wine/update-wine-tkg.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S nix shell .#npins -c bash
+for pkg in wine-tkg{,-ntsync} ; do
+  src=$(npins get-path $pkg)
+  install -D "$src/VERSION" pkgs/wine/$pkg/VERSION
+done

--- a/pkgs/wine/wine-tkg-ntsync/VERSION
+++ b/pkgs/wine/wine-tkg-ntsync/VERSION
@@ -1,0 +1,1 @@
+Wine version 10.12

--- a/pkgs/wine/wine-tkg/VERSION
+++ b/pkgs/wine/wine-tkg/VERSION
@@ -1,0 +1,1 @@
+Wine version 10.12


### PR DESCRIPTION
`wine-tkg` gets its version from the source, causes IFD.
```console
$ nix build .#wine-tkg --option allow-import-from-derivation false
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating the derivation attribute 'name'
         at /nix/store/6hc9hcnav9f2n7sp54piay1njhzj3pbv-source/pkgs/stdenv/generic/make-derivation.nix:468:13:
          467|           // (optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
          468|             name =
             |             ^
          469|               let

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: cannot build '/nix/store/vzds0581x2f45iv8k3qc5kyvzdiwl3v3-source.drv^out' during evaluation because the option 'allow-import-from-derivation' is disabled
```
This PR adds a simple script to get its version during update CI.