### PR TITLE
wine-tkg{,ntsync}: build with default gcc

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -28,7 +28,7 @@
       wineBuilder = wine: build: extra:
         (import ./wine ({
             inherit inputs self pkgs build pins wine-mono;
-            inherit (pkgs) callPackage fetchFromGitHub fetchurl lib moltenvk pkgsCross pkgsi686Linux stdenv_32bit stdenv wrapCCMulti overrideCC gcc13;
+            inherit (pkgs) callPackage fetchFromGitHub lib moltenvk pkgsCross pkgsi686Linux gccMultiStdenv stdenv wrapCCMulti overrideCC gcc13;
             supportFlags = (import ./wine/supportFlags.nix).${build};
           }
           // extra))

--- a/pkgs/wine/default.nix
+++ b/pkgs/wine/default.nix
@@ -9,10 +9,9 @@
   pkgsi686Linux,
   callPackage,
   fetchFromGitHub,
-  fetchurl,
   moltenvk,
   supportFlags,
-  stdenv_32bit,
+  gccMultiStdenv,
   overrideCC,
   wrapCCMulti,
   gcc13,
@@ -64,6 +63,8 @@ in {
       version = lib.removeSuffix "\n" (lib.removePrefix "Wine version " (builtins.readFile ./wine-tkg/VERSION));
       src = pins.wine-tkg;
       monos = [wine-mono];
+      stdenv = gccMultiStdenv;
+      mingwGccs = with pkgsCross; [mingw32.buildPackages.gcc mingwW64.buildPackages.gcc];
     });
 
   wine-tkg-ntsync = callPackage "${nixpkgs-wine}/pkgs/applications/emulators/wine/base.nix" (lib.recursiveUpdate defaults
@@ -72,6 +73,8 @@ in {
       version = lib.removeSuffix "\n" (lib.removePrefix "Wine version " (builtins.readFile ./wine-tkg-ntsync/VERSION));
       src = pins.wine-tkg-ntsync;
       monos = [wine-mono];
+      stdenv = gccMultiStdenv;
+      mingwGccs = with pkgsCross; [mingw32.buildPackages.gcc mingwW64.buildPackages.gcc];
     });
 
   wine-osu = let


### PR DESCRIPTION
Build time can be reduced since we no longer need to build compilers ourselves.