### PR TITLE
wine-tkg: switch to `wow64` branch

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -224,11 +224,11 @@
         "owner": "Kron4ek",
         "repo": "wine-tkg"
       },
-      "branch": "master",
+      "branch": "wow64",
       "submodules": false,
-      "revision": "8711b2948890ab05e150e8e4f721411cca3a4f94",
-      "url": "https://github.com/Kron4ek/wine-tkg/archive/8711b2948890ab05e150e8e4f721411cca3a4f94.tar.gz",
-      "hash": "sha256-nS9c+z+WtflD9uC8GKGfpSvyYXznJyZBFIPaQ1Hn8QU="
+      "revision": "95c6eed3b8879b123d1590c35b4472256605239c",
+      "url": "https://github.com/Kron4ek/wine-tkg/archive/95c6eed3b8879b123d1590c35b4472256605239c.tar.gz",
+      "hash": "sha256-ZN0sJ0oieIfngcu6zH12jZ3Z/6Kmw2oBwoIqrFevgrI="
     },
     "wine-tkg-ntsync": {
       "type": "Git",


### PR DESCRIPTION
Since we're building wine WoW64 now, I think it's better to use the `wow64` branch.
`ntsync` branch is based on `wow64` branch.
This is the difference between `master` and `wow64`.
```diff
$ git diff master..wow64 wine-tkg-config.txt
diff --git a/wine-tkg-config.txt b/wine-tkg-config.txt
index 347599b80..52531cfe0 100644
--- a/wine-tkg-config.txt
+++ b/wine-tkg-config.txt
@@ -1,4 +1,4 @@
-# Last wine-tkg-staging-fsync-git configuration - Sat Jul 12 11:21:01 AM UTC 2025 :
+# Last wine-tkg-staging-fsync-git configuration - Sat Jul 12 11:23:46 AM UTC 2025 :
 
 Local cfg files used
 
@@ -20,7 +20,8 @@ esync-unix-staging.patch -- ( Using Esync (unix, staging) patchset )
 fsync-unix-staging.patch -- ( Applied fsync patches (unix, staging) )
 fsync_futex_waitv.patch -- ( Applied patches for fsync to support futex_waitv )
 
-LAA-unix-staging.patch -- ( Applied large address aware override support (legacy) )
+enable_dynamic_wow64_def.patch -- ( Enable WINEARCH=wow64 by default )
+LAA-unix-staging-wow64.patch -- ( Applied large address aware override support )
 
 proton-win10-default.patch -- ( Enforce win10 as default wine version )
 proton_battleye.patch -- ( Add support for Proton's Battleye runtime )


```