### PR TITLE
dxvk: adapt for 2.7

### DIFF
--- a/pkgs/dxvk/default.nix
+++ b/pkgs/dxvk/default.nix
@@ -1,14 +1,19 @@
 {
   lib,
+  fetchpatch,
   # Enable an async patch, currently dxvk-gplasync
   withAsync ? true,
   # native inputs:
   meson,
   ninja,
+  pkg-config,
   glslang,
   python3,
   pins,
   # cross compile inputs:
+  withSdl3 ? true,
+  sdl3,
+  withSdl2 ? false,
   SDL2,
   windows,
   stdenv,
@@ -18,8 +23,8 @@ in
   stdenv.mkDerivation {
     name = "dxvk";
     version = lib.removePrefix "v" dxvk.version;
+    src = dxvk;
 
-    enableParallelBuilding = true;
     separateDebugInfo = true;
 
     nativeBuildInputs = [
@@ -28,30 +33,42 @@ in
 
     buildInputs =
       lib.optionals stdenv.targetPlatform.isWindows [windows.pthreads]
-      ++ lib.optionals stdenv.targetPlatform.isLinux [SDL2];
+      ++ lib.optionals stdenv.targetPlatform.isLinux (
+        lib.optional withSdl3 sdl3 ++ lib.optional withSdl2 SDL2
+      );
+
+    depsBuildBuild =
+      [
+        meson
+        ninja
+        glslang
+      ]
+      ++ lib.optional (!stdenv.targetPlatform.isWindows) pkg-config;
 
     postPatch = ''
       patchShebangs ./
     '';
 
-    depsBuildBuild = [
-      meson
-      ninja
-      glslang
+    patches =
+      lib.optional (lib.strings.compareVersions dxvk.version "v2.7" == 0) (fetchpatch {
+        url = "https://github.com/doitsujin/dxvk/commit/daed0c1ce8d39e6dcc1580b753554deb7fcbd2ae.patch";
+        sha256 = "X+dPgYnyfgK/xYFMIvtQ3eSG/hcr8UXGkQ0uHrRwNxY=";
+      })
+      ++ lib.optionals withAsync [
+        (dxvk-gplasync + "/patches/dxvk-gplasync-${lib.removePrefix "v" dxvk-gplasync.version}.patch")
+        (dxvk-gplasync + "/patches/global-dxvk.conf.patch")
+      ];
+
+    mesonFlags = [
+      "--buildtype=release"
+      (lib.mesonEnable "native_glfw" false) # can't find glfw from nixpkgs
+      (lib.mesonEnable "native_sdl2" withSdl2)
+      (lib.mesonEnable "native_sdl3" withSdl3)
     ];
-
-    patches = lib.optionals withAsync [
-      (dxvk-gplasync + "/patches/dxvk-gplasync-${lib.removePrefix "v" dxvk-gplasync.version}.patch")
-      (dxvk-gplasync + "/patches/global-dxvk.conf.patch")
-    ];
-
-    mesonFlags = ["--buildtype=release"];
-
-    src = dxvk;
 
     meta = with lib; {
       license = licenses.zlib;
-      description = " Vulkan-based implementation of D3D9, D3D10 and D3D11 for Linux / Wine";
+      description = "Vulkan-based implementation of D3D8, D3D9, D3D10 and D3D11 for Linux / Wine";
       homepage = "https://github.com/doitsujin/dxvk";
       maintainers = with lib.maintainers; [LunNova];
       platforms = platforms.linux ++ platforms.windows;


### PR DESCRIPTION
Fixes #276

Commit description:
> DXVK's meson.build now has options for enabling specific DXVK Native backends (SDL2, SDL3, GLFW), so the package's arguments are updated to reflect that.
> 
> `enableParallelBuilding` is removed since it is already set by the Meson setup hook in nixpkgs.

SDL3 seemed like the most reasonable backend to enable by default.