### PR TITLE
osu-lazer-bin: use 44100 sample rate, change desktop name

### DIFF
--- a/pkgs/osu-lazer-bin/default.nix
+++ b/pkgs/osu-lazer-bin/default.nix
@@ -48,7 +48,7 @@
         ''
       }
 
-      install -m 444 -D ${contents}/osu!.desktop -t $out/share/applications
+      install -m 444 -D ${contents}/osu!.desktop $out/share/applications/osu-lazer.desktop
       for i in 16 32 48 64 96 128 256 512 1024; do
         install -D ${contents}/osu.png $out/share/icons/hicolor/''${i}x$i/apps/osu.png
       done


### PR DESCRIPTION
- Previously, the true quantum would become ~58 instead of 64 as we expect. This was noted in `pw-top`. osu!lazer uses a 44100Hz sample rate, so edit our default pipewire_latency value to reflect this.

- following the xdg spec, desktop files shouldn't have characters like a space or an ! in their file name. `app2unit` follows this spec quite exactly, causing it to fail when launching osu!lazer. This renames the desktop file to osu-lazer.