### PR TITLE
npins: update

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,20 +18,7 @@
       perSystem = {pkgs, ...}: {
         formatter = pkgs.alejandra;
         # Add to legacyPackages to prevent easyOverlay from including this package in the Overlay.
-        legacyPackages.npins =
-          (pkgs.callPackage (let pins = import ./npins; in pins.npins + "/npins.nix") {})
-        # https://github.com/andir/npins/pull/162
-        .overrideAttrs (prev: {
-            patches =
-              [
-                (pkgs.fetchpatch {
-                  name = "fix-fetchzip.patch";
-                  url = "https://github.com/andir/npins/commit/c91f2042a1f97ed950ebda8cb02828c61dc23c33.patch";
-                  hash = "sha256-Wqg89RH7C9ln5CLm+kQRwRWd5VOtAB8QuNVrMjug0qI=";
-                })
-              ]
-              ++ prev.patches;
-          });
+        legacyPackages.npins = pkgs.callPackage (let pins = import ./npins; in pins.npins + "/npins.nix") {};
       };
     };
 

--- a/npins/default.nix
+++ b/npins/default.nix
@@ -33,7 +33,6 @@ let
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L269
   stringAsChars = f: s: concatStrings (map f (stringToCharacters s));
-  concatMapStrings = f: list: concatStrings (map f list);
   concatStrings = builtins.concatStringsSep "";
 
   # If the environment variable NPINS_OVERRIDE_${name} is set, then use
@@ -120,7 +119,6 @@ let
     url ? null,
     submodules,
     hash,
-    branch ? null,
     ...
   }:
     assert repository ? type;

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -122,9 +122,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "afa9fe50cb0bff9ba7e9f7796892f71722b2180d",
-      "url": "https://github.com/andir/npins/archive/afa9fe50cb0bff9ba7e9f7796892f71722b2180d.tar.gz",
-      "hash": "sha256-D6dYAMk9eYpBriE07s8Q7M3WBT7uM9pz3RKIoNk+h7I=",
+      "revision": "e49bcf58d66fa7f586aff687feae72c23e429672",
+      "url": "https://github.com/andir/npins/archive/e49bcf58d66fa7f586aff687feae72c23e429672.tar.gz",
+      "hash": "sha256-ZLrVWa7WU+IUXPAd6mR7B9c6FDZSiGgW8ClfW0SxbMs=",
       "frozen": true
     },
     "proton-osu": {


### PR DESCRIPTION
andir/npins#162 has been merged so the patch is no longer needed.