### PR TITLE
wine-tkg-ntsync: remove

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
           - wine-ge
           - wine-osu
           - wine-tkg
-          - wine-tkg-ntsync
           - wineprefix-preparer
           - umu-launcher
 

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -229,19 +229,6 @@
       "url": "https://github.com/Kron4ek/wine-tkg/archive/c2e0a14b32813b400e7b5bf10ec740e8e6d879f1.tar.gz",
       "hash": "sha256-ywlTLB8CbP1W9mNzN9iN1e1Tbg2OV9HYx2ReDxuFiBs="
     },
-    "wine-tkg-ntsync": {
-      "type": "Git",
-      "repository": {
-        "type": "GitHub",
-        "owner": "Kron4ek",
-        "repo": "wine-tkg"
-      },
-      "branch": "ntsync",
-      "submodules": false,
-      "revision": "0d14294f54462ee2847d0266adf2024a58d08a19",
-      "url": "https://github.com/Kron4ek/wine-tkg/archive/0d14294f54462ee2847d0266adf2024a58d08a19.tar.gz",
-      "hash": "sha256-aeHNtLc6vOLZ9wR/nhw8uiOThfK7iPqBHoZJ10Fb3lM="
-    },
     "winetricks": {
       "type": "Git",
       "repository": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -160,8 +160,6 @@
 
       wine-tkg = wineBuilder "wine-tkg" "full" {};
 
-      wine-tkg-ntsync = wineBuilder "wine-tkg-ntsync" "full" {};
-
       winetricks-git = pkgs.callPackage ./winetricks-git {inherit pins;};
 
       wineprefix-preparer = pkgs.callPackage ./wineprefix-preparer {inherit (config.packages) dxvk-w32 vkd3d-proton-w32 dxvk-w64 vkd3d-proton-w64 dxvk-nvapi-w32 dxvk-nvapi-w64 cnc-ddraw;};

--- a/pkgs/wine/default.nix
+++ b/pkgs/wine/default.nix
@@ -99,14 +99,6 @@ in rec {
       src = pins.wine-tkg;
     });
 
-  wine-tkg-ntsync =
-    wine-tkg.override
-    {
-      pname = pnameGen "wine-tkg-ntsync";
-      version = lib.removeSuffix "\n" (lib.removePrefix "Wine version " (builtins.readFile ./wine-tkg-ntsync/VERSION));
-      src = pins.wine-tkg-ntsync;
-    };
-
   wine-osu = let
     pname = pnameGen "wine-osu";
     version = "7.0";

--- a/pkgs/wine/update-wine-tkg.sh
+++ b/pkgs/wine/update-wine-tkg.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env -S nix shell .#npins -c bash
-for pkg in wine-tkg{,-ntsync} ; do
-  src=$(npins get-path $pkg)
-  install -D "$src/VERSION" pkgs/wine/$pkg/VERSION
-done
+src=$(npins get-path wine-tkg)
+install -D "$src/VERSION" pkgs/wine/wine-tkg/VERSION


### PR DESCRIPTION
[NTSync has been upstreamed into Wine](https://www.winehq.org/news/2025100301), meaning that regular `wine-tkg` also includes it.
In fact, [the NTSync branch of Kron4ek](https://github.com/Kron4ek/wine-tkg/tree/ntsync) has not been updated.

Tested that `wine-tkg` does indeed use NTSync (through MangoHud).