### PR TITLE
wine-mono: 10.1.0 -> 10.3.0

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -34,6 +34,7 @@ jobs:
           pkgs/wine/update-wine-cachyos.sh
           pkgs/wine/update-wine-ge.sh
           pkgs/wine/update-wine-tkg.sh
+          pkgs/wine-mono/update.sh
           pkgs/star-citizen/update.sh
 
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/pkgs/wine-mono/info.json
+++ b/pkgs/wine-mono/info.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-yIwkMYkLwyys7I1+pw5Tpa5LlcjFXKbnXvjbDkzPEHA=",
-  "storePath": "/nix/store/zj00512i9lf2m6pbzq2ajlh3zliz5i9d-wine-mono-10.1.0-x86.msi",
-  "version": "wine-mono-10.1.0"
+  "hash": "sha256-zs5cYxgAlN/98B0PvjYqS2BuUoC5jN/RuFaM35tXL5g=",
+  "storePath": "/nix/store/c18xfwygni1dinql4rfz1rfzqshf2s4y-wine-mono-10.3.0-x86.msi",
+  "version": "wine-mono-10.3.0"
 }

--- a/pkgs/wine/wine-tkg-ntsync/VERSION
+++ b/pkgs/wine/wine-tkg-ntsync/VERSION
@@ -1,1 +1,0 @@
-Wine version 10.15


### PR DESCRIPTION
[Wine now uses Mono 10.3.0](https://www.winehq.org/news/2025101701).
Untested.