### PR TITLE
Fix overlay

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -223,7 +223,7 @@
       config.allowUnfree = true;
     };
 
-    overlayAttrs = config.packages';
+    overlayAttrs = packages';
 
     packages = packages' // deprecationNotices;
   };


### PR DESCRIPTION
```console
        error: attribute 'packages'' missing
       at «github:fufexan/nix-gaming/0be39800d7d8a2637f9581ae0fe15646d7527c49?narHash=sha256-5L3lprESLbFKeCYOtOzyxySOFaEvifT67q5ua3Vz6os%3D»/pkgs/default.nix:226:20:
          225|
          226|     overlayAttrs = config.packages';
             |                    ^
          227|
       Did you mean packages?
```