### PR TITLE
osu-mime: fixed hash mismatch on dependency

### DIFF
--- a/pkgs/osu-mime/default.nix
+++ b/pkgs/osu-mime/default.nix
@@ -23,7 +23,7 @@ in
       })
       (fetchurl {
         url = "https://aur.archlinux.org/cgit/aur.git/plain/osu-file-extensions.xml?h=osu-mime&id=${osu-mime-spec-rev}";
-        sha256 = "MgQNW0RpnEYTC0ym6wB8cA6a8GCED1igsjOtHPXNZVo=";
+        sha256 = "vAg2ilU+ITaE3KSYKAAqbqq9+M2pTXFp/dSyzWgtNiY=";
       })
     ];
 


### PR DESCRIPTION
Correction on simple hash mismatch for dependency of `osu-mime` package.