### PR TITLE
Fix osu-mime hash mismatch

### DIFF
--- a/pkgs/osu-mime/default.nix
+++ b/pkgs/osu-mime/default.nix
@@ -23,7 +23,7 @@ in
       })
       (fetchurl {
         url = "https://aur.archlinux.org/cgit/aur.git/plain/osu-file-extensions.xml?h=osu-mime&id=${osu-mime-spec-rev}";
-        sha256 = "vAg2ilU+ITaE3KSYKAAqbqq9+M2pTXFp/dSyzWgtNiY=";
+        sha256 = "wPfIXciB16enarOjRjiGUN++fFFm70xRLr2cm/fr5Js=";
       })
     ];
 


### PR DESCRIPTION
Seems to have been updated yesterday
ab846ed41d1a9b7f5ec0b36d2ccfbefe7208a330

 but getting mismatch again