### PR TITLE
use umu-launcher-git instead of umu-launcher as deprecrated.

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -137,7 +137,7 @@
       };
 
       osu-stable = pkgs.callPackage ./osu-stable {
-        inherit (config.packages) osu-mime proton-osu-bin umu-launcher;
+        inherit (config.packages) osu-mime proton-osu-bin umu-launcher-git;
         wine = config.packages.wine-osu;
         wine-discord-ipc-bridge = config.packages.wine-discord-ipc-bridge.override {
           wine = config.packages.wine-osu;
@@ -170,7 +170,7 @@
         wine = config.packages.wine-tkg;
         winetricks = config.packages.winetricks-git;
 
-        inherit (config.packages) umu-launcher wineprefix-preparer;
+        inherit (config.packages) umu-launcher-git wineprefix-preparer;
       };
       star-citizen-umu = config.packages.star-citizen.override {useUmu = true;};
 

--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -8,7 +8,7 @@
   wine-discord-ipc-bridge,
   winetricks,
   wine,
-  umu-launcher,
+  umu-launcher-git,
   proton-osu-bin,
   wineFlags ? "",
   pname ? "osu-stable",
@@ -51,7 +51,7 @@
     PATH=${
       lib.makeBinPath (
         if useUmu
-        then [umu-launcher]
+        then [umu-launcher-git]
         else [wine winetricks]
       )
     }:$PATH

--- a/pkgs/star-citizen/default.nix
+++ b/pkgs/star-citizen/default.nix
@@ -7,7 +7,7 @@
   winetricks,
   wine,
   wineprefix-preparer,
-  umu-launcher,
+  umu-launcher-git,
   proton-ge-bin,
   wineFlags ? "",
   pname ? "star-citizen",
@@ -78,7 +78,7 @@
     PATH=${
       lib.makeBinPath (
         if useUmu
-        then [umu-launcher]
+        then [umu-launcher-git]
         else [wine winetricks]
       )
     }:$PATH


### PR DESCRIPTION
Hello, I decided to do this commit because of the error messages that would be thrown because by default star-citizen and osu-stable still use the old umu-launcher naming scheme instead of the umu-launcher-git so there would be evaluation errors while building a new nixos generation.