### PR TITLE
rpc-bridge: init at 1.4.0.1

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -160,6 +160,22 @@
       "hash": "sha256-yJnJ7D/QHvZ+ieR8nAAnkFV8pzQkDaYDs0Xvo9YsDQA=",
       "frozen": true
     },
+    "rpc-bridge": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "EnderIce2",
+        "repo": "rpc-bridge"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "v1.4.0.1",
+      "revision": "340243a1c9a461ab36b0ab356cff5d1edf17bea1",
+      "url": "https://api.github.com/repos/EnderIce2/rpc-bridge/tarball/refs/tags/v1.4.0.1",
+      "hash": "sha256-NB3GqwlJ1dkI+MmbjDEDhiAvvAtRHOdC/PEEyIP2i28="
+    },
     "umu-launcher": {
       "type": "Git",
       "repository": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -166,6 +166,8 @@
 
       rocket-league = pkgs.callPackage ./rocket-league {wine = config.packages.wine-tkg;};
 
+      rpc-bridge = pkgs.callPackage ./rpc-bridge {inherit pins;};
+
       star-citizen = pkgs.callPackage ./star-citizen {
         wine = config.packages.wine-tkg;
         winetricks = config.packages.winetricks-git;

--- a/pkgs/rpc-bridge/default.nix
+++ b/pkgs/rpc-bridge/default.nix
@@ -1,0 +1,53 @@
+{
+  stdenv,
+  lib,
+  pins,
+  pkgsCross,
+}: let
+  inherit (pins) rpc-bridge;
+in
+  stdenv.mkDerivation {
+    pname = "rpc-bridge";
+    version = lib.removePrefix "v" rpc-bridge.version;
+
+    src = rpc-bridge;
+
+    nativeBuildInputs = [
+      pkgsCross.mingwW64.stdenv.cc
+    ];
+
+    makeFlags = [
+      "GIT_COMMIT=${builtins.substring 0 7 rpc-bridge.revision}"
+      "GIT_BRANCH=master"
+    ];
+
+    enableParallelBuilding = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+
+      cp build/bridge.exe $out/bin
+
+      ${
+        if stdenv.isDarwin
+        then ''
+          cp build/launchd.sh $out/bin
+        ''
+        else ''
+          cp build/bridge.sh $out/bin
+        ''
+      }
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Discord RPC Bridge for Wine";
+      homepage = "https://github.com/EnderIce2/rpc-bridge";
+      maintainers = with lib.maintainers; [ccicnce113424];
+      platforms = lib.platforms.unix;
+      license = lib.licenses.mit;
+    };
+  }


### PR DESCRIPTION
This PR adds a Discord RPC Bridge for Wine, which can be installed as a service, eliminating the need for manual startup.
https://github.com/EnderIce2/rpc-bridge