### PR TITLE
use umu-launcher-unwrapped-git with umu-launcher-git

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -93,7 +93,7 @@
         };
       umu-launcher-git = pkgs.callPackage "${pins.umu-launcher}/packaging/nix/package.nix" {
         inherit (pkgs) umu-launcher;
-        inherit (config.packages) umu-launcher-unwrapped;
+        umu-launcher-unwrapped = config.packages.umu-launcher-unwrapped-git;
       };
 
       cnc-ddraw = pkgs.callPackage ./cnc-ddraw {};


### PR DESCRIPTION
Even after #336 was merged, I have still been getting deprecation warnings, this time for `umu-launcher-unwrapped`. It seems `umu-launcher-git` itself was dependent on the deprecated `umu-launcher-unwrapped`, so this is a small fix to rectify that.