### PR TITLE
wine-cachyos: get release tag from cachyos upstream

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -222,17 +222,20 @@
       "hash": "sha256-OTq3FmDyJGDUDYRq7PQv3bOXn/gf2qlBVcA9lVfHB3E="
     },
     "wine-cachyos": {
-      "type": "Git",
+      "type": "GitRelease",
       "repository": {
         "type": "GitHub",
         "owner": "CachyOS",
         "repo": "wine-cachyos"
       },
-      "branch": "cachyos_10.0_20260102/main",
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
       "submodules": false,
-      "revision": "ba41b39c39b5fca02ee23effeaf4f6a17ca71919",
-      "url": "https://github.com/CachyOS/wine-cachyos/archive/ba41b39c39b5fca02ee23effeaf4f6a17ca71919.tar.gz",
-      "hash": "sha256-CUT0CpR7lW7D9Z1aL3j71LysQxcvXeSukSOrH9f6Rkc=",
+      "version": "cachyos-10.0-20260101-wine",
+      "revision": "f064d80d09236a8aa95ec210abcab85433eb0754",
+      "url": "https://api.github.com/repos/CachyOS/wine-cachyos/tarball/refs/tags/cachyos-10.0-20260101-wine",
+      "hash": "sha256-RuaTIKYkGkaK+UIFmknRVqPRV4z0+U/6hvgPObPN0oQ=",
       "frozen": true
     },
     "wine-discord-ipc-bridge": {

--- a/pkgs/wine/default.nix
+++ b/pkgs/wine/default.nix
@@ -64,11 +64,7 @@ in {
   wine-cachyos =
     (callPackage "${nixpkgs-wine}/pkgs/applications/emulators/wine/base.nix" (lib.recursiveUpdate defaultsWow64 {
       pname = pnameGen "wine-cachyos";
-      version = lib.pipe pins.wine-cachyos.branch [
-        (lib.removePrefix "cachyos_")
-        (lib.removeSuffix "/main")
-        (lib.replaceString "_" ".")
-      ];
+      version = lib.removeSuffix "-wine" (lib.removePrefix "cachyos-" pins.wine-cachyos.version);
       src = pins.wine-cachyos;
     }))
     # https://github.com/CachyOS/CachyOS-PKGBUILDS/blob/b76138d70274f3ba6f7e0f7ca62fa2e335b93ad6/wine-cachyos/PKGBUILD#L116


### PR DESCRIPTION
I think the build failure is simply because an unready branch was selected that hasn't been adopted by the CachyOS upstream.