### PR TITLE
wine: fix build with latest nixpkgs, refactor

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770380644,
-        "narHash": "sha256-P7dWMHRUWG5m4G+06jDyThXO7kwSk46C1kgjEWcybkE=",
+        "lastModified": 1770537093,
+        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ae67888ff7ef9dff69b3cf0cc0fbfbcd3a722abe",
+        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
         "type": "github"
       },
       "original": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -49,29 +49,14 @@
       wine-mono = pkgs.callPackage ./wine-mono {};
 
       wineBuilder = wine: build: extra:
-        (import ./wine (
+        (pkgs.callPackage ./wine (
           {
             inherit
-              inputs
               self
               pkgs
               build
               pins
               wine-mono
-              ;
-            inherit
-              (pkgs)
-              callPackage
-              fetchFromGitHub
-              replaceVars
-              lib
-              moltenvk
-              pkgsCross
-              pkgsi686Linux
-              stdenv
-              wrapCCMulti
-              overrideCC
-              gcc13
               ;
             supportFlags = (import ./wine/supportFlags.nix).${build};
           }


### PR DESCRIPTION
NixOS/nixpkgs#487421 removed wineRelease option from `base.nix`.

By replacing string interpolation with path concatenation, we reduced one copy operation to the store.