### PR TITLE
osu-stable: open folders on native file browser

### DIFF
--- a/pkgs/osu-stable/README.md
+++ b/pkgs/osu-stable/README.md
@@ -15,3 +15,5 @@ This package has the following additional overrides:
 - `protonPath` Proton compatibility tool if umu is used.
 Defaults to [`proton-osu-bin`](../proton-osu-bin/README.md).
 - `protonVerbs`
+- `nativeFileManager` Native Linux file manager binary used when opening
+folders inside the game. Defaults to `xdg-open`.


### PR DESCRIPTION
Updates the `osu-stable` package so that folders are opened inside the user's native file manager (Dolphin, Nautilus, etc) instead of Wine's default file browser.

Mostly useful for interacting with the editor, but can be helpful in other scenarios, like accessing skin/replay exports and in-game screenshots.