### PR TITLE
low_latency_layer: init at 0.1.0

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -129,6 +129,22 @@
       "url": "https://api.github.com/repos/FAForever/uid/tarball/refs/tags/v4.0.7",
       "hash": "sha256-UjDE3Eyj9Q2S76sIInUNpvCXqB7ahoYyBhwcSg5l1O0="
     },
+    "low_latency_layer": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "Korthos-Software",
+        "repo": "low_latency_layer"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "v0.1.0",
+      "revision": "5bfb73f9f85ce3f72d997bb9d72360e344bee0ec",
+      "url": "https://api.github.com/repos/Korthos-Software/low_latency_layer/tarball/refs/tags/v0.1.0",
+      "hash": "sha256-YYQpLC3yCvqbArhqeWkZ8rRhVT69qz31SHr5dxXc0zM="
+    },
     "npins": {
       "type": "GitRelease",
       "repository": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -104,6 +104,8 @@
           # broken upstream, thanks tauri
           # flight-core = pkgs.callPackage ./titanfall/flight-core.nix {};
 
+          low-latency-layer = pkgs.callPackage ./low-latency-layer { inherit pins; };
+
           mo2installer = pkgs.callPackage ./mo2installer { };
 
           modrinth-app = pkgs.callPackage ./modrinth-app { };

--- a/pkgs/low-latency-layer/default.nix
+++ b/pkgs/low-latency-layer/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  vulkan-headers,
+  vulkan-loader,
+  vulkan-utility-libraries,
+  pins,
+}:
+let
+  inherit (pins) low_latency_layer;
+in
+stdenv.mkDerivation {
+  pname = "low_latency_layer";
+  version = lib.removePrefix "v" low_latency_layer.version;
+  src = low_latency_layer;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+    vulkan-utility-libraries
+  ];
+
+  separateDebugInfo = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Vulkan layer for hardware agnostic input latency reduction ";
+    homepage = "https://github.com/Korthos-Software/low_latency_layer";
+    changelog = "https://github.com/Korthos-Software/low_latency_layer/releases/tag/${low_latency_layer.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ccicnce113424 ];
+  };
+}


### PR DESCRIPTION
This is a hardware-agnostic implementation of low-latency device extensions and can serve as an alternative to the `dxvk-nvapi` Vulkan layer.
https://github.com/Korthos-Software/low_latency_layer
https://www.phoronix.com/news/Low-Latency-Layer