### PR TITLE
wine: fix breakage with nixpkgs 26.05

### DIFF
--- a/pkgs/wine/default.nix
+++ b/pkgs/wine/default.nix
@@ -57,7 +57,7 @@ let
     };
 
   # defaults for newer WoW64 builds
-  defaultsWow64 = lib.recursiveUpdate (removeAttrs defaults [ "buildScript" ]) {
+  defaultsWow64 = lib.recursiveUpdate (removeAttrs defaults [ "buildScript" "supportFlags" ]) {
     configureFlags = [
       "--disable-tests"
       "--enable-archs=x86_64,i386"
@@ -106,7 +106,7 @@ in
 
   wine-ge =
     (callPackage (nixpkgs-wine + "/pkgs/applications/emulators/wine/base.nix") (
-      defaults
+      removeAttrs defaults [ "supportFlags" ]
       // {
         pname = pnameGen "wine-ge";
         version = pins.proton-wine.branch;
@@ -142,7 +142,7 @@ in
       };
     in
     (callPackage (nixpkgs-wine + "/pkgs/applications/emulators/wine/base.nix") (
-      defaults
+      removeAttrs defaults [ "supportFlags" ]
       // rec {
         inherit version pname;
         src = fetchFromGitHub {


### PR DESCRIPTION
Hello!

Nixpkgs 26.05 seems to have removed `supportFlags` attrset argument from `pkgs/applications/emulators/wine/base.nix`, replacing it with individual top-level arguments (`gettextSupport`, `fontconfigSupport`, etc.) that each have their own defaults.

`nix-gaming` was passing `supportFlags` as a single attrset into `callPackage`, which now fails with:

```
error: function 'anonymous lambda' called with unexpected argument 'supportFlags'
    at nixpkgs/pkgs/applications/emulators/wine/base.nix:1:1
```

Fix: strip `supportFlags` from `defaults` and `defaultsWow64` before passing them to `base.nix` using `removeAttrs`. The individual flags are already spread into `defaults` via `supportFlags // {...}`, so `callPackage` auto-binds them correctly into `base.nix`'s top-level args. `supportFlags.nix` remains unchanged.

I've tested this on NixOS 26.05 and had no issues after that.

PS: I am new to nix, and this is my first pull request. Hope I did things as they are supposed to be done. Otherwise please advise, I would like to learn.