### PR TITLE
d7vk: get latest release from GitHub API

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,6 +24,7 @@ jobs:
       - run: |
           nix run .#npins update
           pkgs/cnc-ddraw/update.sh
+          pkgs/d7vk/update.sh
           pkgs/dxvk/update.sh
           pkgs/faf-client/update.sh
           pkgs/faf-client/update-src.sh

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -8,13 +8,14 @@
         "repo": "d7vk"
       },
       "pre_releases": false,
-      "version_upper_bound": "v2.7.1",
+      "version_upper_bound": null,
       "release_prefix": null,
       "submodules": true,
-      "version": "v2.0",
-      "revision": "ea9594a6d0684533b275b8d9e87dffc9044808d3",
+      "version": "v1.12",
+      "revision": "520a79a80846b69b93218e41f3713e69fb81d85d",
       "url": null,
-      "hash": "sha256-eM18O/y7+C1KGXuTRyUrupajM8KHvnAeGOOAwqgezK4="
+      "hash": "sha256-UeIHb7kCsKWmfEA/dyi3xDVFnNpNr7uVmfs7cBKDYEM=",
+      "frozen": true
     },
     "downlords-faf-client": {
       "type": "GitRelease",

--- a/pkgs/d7vk/update.sh
+++ b/pkgs/d7vk/update.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S nix shell nixpkgs#curl nixpkgs#jq .#npins -c bash
+
+set -eu
+
+releases="$(curl -fsSL "https://api.github.com/repos/WinterSnowfall/d7vk/releases")"
+version=$(jq -r '.[0].tag_name' <<<"$releases")
+
+npins add github --submodules --frozen --at $version WinterSnowfall d7vk


### PR DESCRIPTION
d7vk's repository may contain some upstream Git tags, so it's safer to use GitHub Releases.