### PR TITLE
osu-lazer-bin: fix opengl renderer on nvidia + wayland

### DIFF
--- a/pkgs/osu-lazer-bin/default.nix
+++ b/pkgs/osu-lazer-bin/default.nix
@@ -33,6 +33,11 @@ let
 
     extraPkgs = pkgs: [ pkgs.icu ];
 
+    # fix OpenGL renderer on nvidia + wayland
+    extraBwrapArgs = [
+      "--ro-bind-try /etc/egl/egl_external_platform.d /etc/egl/egl_external_platform.d"
+    ];
+
     extraInstallCommands =
       let
         contents = appimageTools.extract { inherit pname version src; };


### PR DESCRIPTION
fixes #300 without forcing the vulkan renderer, which caused hard freezes (tested on my GTX 1080 machine).
based on nixpkgs https://github.com/NixOS/nixpkgs/pull/462052