### PR TITLE
treewide: fix `stdenv.${name}` deprecation warning

### DIFF
--- a/pkgs/faf-client/bin.nix
+++ b/pkgs/faf-client/bin.nix
@@ -87,7 +87,7 @@ let
     # lspci
     pciutils
   ]
-  ++ lib.optionals stdenvNoCC.isLinux [
+  ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [
     # lsblk
     util-linux
     xrandr

--- a/pkgs/faf-client/default.nix
+++ b/pkgs/faf-client/default.nix
@@ -66,7 +66,7 @@ let
     ];
   };
 
-  libs = lib.optionals stdenvNoCC.isLinux [
+  libs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
     alsa-lib
     fontconfig
     freetype
@@ -80,16 +80,16 @@ let
   ];
 
   jfxPlatform =
-    if stdenvNoCC.isDarwin then
+    if stdenvNoCC.hostPlatform.isDarwin then
       (
-        if stdenvNoCC.isAarch64 then
+        if stdenvNoCC.hostPlatform.isAarch64 then
           "mac-aarch64"
-        else if stdenvNoCC.isx86_64 then
+        else if stdenvNoCC.hostPlatform.isx86_64 then
           "mac"
         else
           null
       )
-    else if stdenvNoCC.isLinux then
+    else if stdenvNoCC.hostPlatform.isLinux then
       "linux"
     else
       null;

--- a/pkgs/faf-client/ice-adapter.nix
+++ b/pkgs/faf-client/ice-adapter.nix
@@ -12,16 +12,16 @@ let
   version = builtins.replaceStrings [ "v" ] [ "" ] src.version;
 
   jfxPlatform =
-    if stdenvNoCC.isDarwin then
+    if stdenvNoCC.hostPlatform.isDarwin then
       (
-        if stdenvNoCC.isAarch64 then
+        if stdenvNoCC.hostPlatform.isAarch64 then
           "mac-aarch64"
-        else if stdenvNoCC.isx86_64 then
+        else if stdenvNoCC.hostPlatform.isx86_64 then
           "mac"
         else
           null
       )
-    else if stdenvNoCC.isLinux then
+    else if stdenvNoCC.hostPlatform.isLinux then
       "linux"
     else
       null;

--- a/pkgs/faf-client/uid.nix
+++ b/pkgs/faf-client/uid.nix
@@ -20,7 +20,7 @@ let
     # lspci
     pciutils
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     # lsblk
     util-linux
     # xrandr

--- a/pkgs/rpc-bridge/default.nix
+++ b/pkgs/rpc-bridge/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
     cp build/bridge.exe $out/bin
 
     ${
-      if stdenv.isDarwin then
+      if stdenv.hostPlatform.isDarwin then
         ''
           cp build/launchd.sh $out/bin
         ''


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/518407