### PR TITLE
osu-stable: Fix non-umu installation

### DIFF
--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -76,8 +76,6 @@ let
 
   script = writeShellScriptBin pname ''
     export WINEPREFIX="${location}"
-    # required, otherwise installation freezes
-    export WINEDLLOVERRIDES="winemenubuilder.exe=;"
     # sets realtime priority for wine
     export STAGING_RT_PRIORITY_SERVER=1
     # disables vsync for OpenGL
@@ -140,6 +138,8 @@ let
       else
         ''
           if [ ! -d "$WINEPREFIX" ]; then
+            # required, otherwise installation freezes multiple times with wine-osu
+            wine reg add 'HKCU\Software\Wine\DllOverrides' /v 'winemenubuilder.exe' /t REG_SZ /d ""
             # install tricks
             winetricks -q -f ${tricksFmt}
             wineserver -k

--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -75,7 +75,6 @@ let
   '';
 
   script = writeShellScriptBin pname ''
-    export WINEARCH="win32"
     export WINEPREFIX="${location}"
     # sets realtime priority for wine
     export STAGING_RT_PRIORITY_SERVER=1

--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -76,6 +76,8 @@ let
 
   script = writeShellScriptBin pname ''
     export WINEPREFIX="${location}"
+    # required, otherwise installation freezes
+    export WINEDLLOVERRIDES="winemenubuilder.exe=;"
     # sets realtime priority for wine
     export STAGING_RT_PRIORITY_SERVER=1
     # disables vsync for OpenGL

--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -143,7 +143,9 @@ let
             # install tricks
             winetricks -q -f ${tricksFmt}
             wineserver -k
+          fi
 
+          if [ ! -f "$OSU" ]; then
             # install osu
             wine ${src}
             wineserver -k

--- a/pkgs/osu-stable/default.nix
+++ b/pkgs/osu-stable/default.nix
@@ -163,7 +163,9 @@ let
         ''
       else
         ''
-          wine ${wine-discord-ipc-bridge}/bin/winediscordipcbridge.exe &
+          ${lib.optionalString (
+            wine-discord-ipc-bridge != null
+          ) "wine ${wine-discord-ipc-bridge}/bin/winediscordipcbridge.exe &"}
           ${gameMode} wine ${wineFlags} "$OSU" "$@"
           wineserver -w
         ''


### PR DESCRIPTION
Now that `wine-osu` is usable again, there's a few bugs in the non-umu process that I discovered needs to be fixed.

1. `WINEARCH` export has been completely removed. `WINEARCH=win32` stopped working with newer version of wine, and in fact causes it to fail immediately. From my brief testing, there's no problems leaving that out and letting `wine` assume `WINEARCH=win64`.
2. A registry key is added to disable `winemenubuilder.exe`. If this isn't disabled, then with `wine-osu`, `winetricks` will hang several times across the installation waiting for a non-functional executable to close and force manual `wineserver -k`s. Setting this in `WINEDLLOVERRIDES` doesn't work, since `winetricks` will end up overriding that itself. This apparently throws a few more warnings up from time to time, but functionally should cause no issues, since we already package our own desktop file.
3. Added the ability to disable `wine-discord-ipc-bridge` entirely if it's set to `null`. I found that it crashes on startup with my setup, and some people might just not want it running otherwise.

As a bonus, I also split the install process between the winetricks section and actually installing osu, the same way the umu installation does it.

Side note, should we also set `useUmu` to false by default? `proton-osu` is no longer updated and `wine-osu` is newer and presumably better, but I worry about wineprefix compatibility for those who already have `umu` set up.